### PR TITLE
fix: lastmod regex issue

### DIFF
--- a/.playground/nuxt.config.ts
+++ b/.playground/nuxt.config.ts
@@ -158,7 +158,7 @@ export default defineNuxtConfig({
     },
     '/about': {
       sitemap: {
-        lastmod: new Date(2023, 1, 21, 8, 50, 52),
+        lastmod: "2023-01-21",
         changefreq: 'daily',
         priority: 0.3,
         images: [

--- a/src/runtime/nitro/sitemap/urlset/normalise.ts
+++ b/src/runtime/nitro/sitemap/urlset/normalise.ts
@@ -107,7 +107,8 @@ export function normaliseDate(d: Date | string) {
     d = d.replace(/\.\d+$/, '')
     // we may have a value like this "2023-12-21T13:49:27", this needs to be converted to w3c datetime
     // accept if they are already in the right format, accept small format too such as "2023-12-21"
-    if (d.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/) || d.match(/^\d{4}-\d{2}-\d{2}$/))
+    const validW3CDate = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))/
+    if (d.match(validW3CDate) || d.match(/^\d{4}-\d{2}-\d{2}$/))
       return d
 
     // otherwise we need to parse it

--- a/test/integration/content/default.test.ts
+++ b/test/integration/content/default.test.ts
@@ -29,11 +29,11 @@ describe('nuxt/content default', () => {
       <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
           <url>
               <loc>https://nuxtseo.com/blog/posts/bar</loc>
-              <lastmod>2021-10-20T00:00:00</lastmod>
+              <lastmod>2021-10-20T00:00:00+00:00</lastmod>
           </url>
           <url>
               <loc>https://nuxtseo.com/blog/posts/fallback</loc>
-              <lastmod>2021-10-20T00:00:00</lastmod>
+              <lastmod>2021-10-20T00:00:00+00:00</lastmod>
           </url>
       </urlset>"
     `)

--- a/test/integration/content/documentDriven.test.ts
+++ b/test/integration/content/documentDriven.test.ts
@@ -32,11 +32,11 @@ describe('nuxt/content documentDriven', () => {
       <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
           <url>
               <loc>https://nuxtseo.com/blog/posts/bar</loc>
-              <lastmod>2021-10-20T00:00:00</lastmod>
+              <lastmod>2021-10-20T00:00:00+00:00</lastmod>
           </url>
           <url>
               <loc>https://nuxtseo.com/blog/posts/fallback</loc>
-              <lastmod>2021-10-20T00:00:00</lastmod>
+              <lastmod>2021-10-20T00:00:00+00:00</lastmod>
           </url>
       </urlset>"
     `)

--- a/test/integration/single/lastmod.test.ts
+++ b/test/integration/single/lastmod.test.ts
@@ -53,21 +53,21 @@ describe('lastmod', () => {
           </url>
           <url>
               <loc>https://nuxtseo.com/baz</loc>
-              <lastmod>2023-12-21T13:49:27</lastmod>
+              <lastmod>2023-12-21T13:49:27+00:00</lastmod>
           </url>
           <url>
               <loc>https://nuxtseo.com/crawled</loc>
           </url>
           <url>
               <loc>https://nuxtseo.com/foo</loc>
-              <lastmod>2023-12-21T13:49:27</lastmod>
+              <lastmod>2023-12-21T13:49:27+00:00</lastmod>
           </url>
           <url>
               <loc>https://nuxtseo.com/quux</loc>
           </url>
           <url>
               <loc>https://nuxtseo.com/qux</loc>
-              <lastmod>2023-12-21T13:49:27</lastmod>
+              <lastmod>2023-12-21T13:49:27+00:00</lastmod>
           </url>
           <url>
               <loc>https://nuxtseo.com/sub/page</loc>


### PR DESCRIPTION
### Pull Request Description

This Pull Request addresses the regex to comply with W3C specifications and adjusts the lastmod format in the sitemap file to adhere to W3C conventions.

### Proposed Changes

#### Regex

- Corrected the regex to align with W3C specifications.
- Conducted tests to ensure the new regex works correctly in various use cases.

### Compliance Check

- [ X ] Reviewed and followed the project's contribution guidelines.
- [ X ] Tests have passed successfully.

## Issues
- https://github.com/nuxt-modules/sitemap/issues/208
- https://github.com/nuxt-modules/sitemap/issues/206

## Tests
### BEFORE
![image](https://github.com/nuxt-modules/sitemap/assets/20051792/110cf9cb-bfb3-4e77-b896-26822fa0ab4b)

### AFTER
![image](https://github.com/nuxt-modules/sitemap/assets/20051792/487353d6-b3aa-48ff-a593-87aab53ad312)