### PR TITLE
fix: config `MultiSitemapsInput` types

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -152,7 +152,7 @@ export interface MultiSitemapEntry {
   [key: string]: Partial<SitemapDefinition>
 }
 
-export type MultiSitemapsInput = Partial<MultiSitemapEntry & IndexSitemapRemotes>
+export type MultiSitemapsInput = Partial<MultiSitemapEntry> & Partial<IndexSitemapRemotes>
 
 export type MaybeFunction<T> = T | (() => T)
 export type MaybePromise<T> = T | Promise<T>


### PR DESCRIPTION
fix config `MultiSitemapsInput` types:

```ts
 Property 'index' is incompatible with index signature.
      Type '{ sitemap: string; }[]' has no properties in common with type 'Partial<SitemapDefinition>'.ts(2322)
```