### PR TITLE
chore: import i18n types directly from module

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -13,7 +13,7 @@ import {
 } from '@nuxt/kit'
 import { withBase, withoutLeadingSlash } from 'ufo'
 import { installNuxtSiteConfig } from 'nuxt-site-config-kit'
-import type { NuxtI18nOptions } from '@nuxtjs/i18n/dist/module'
+import type { NuxtI18nOptions } from '@nuxtjs/i18n'
 import { defu } from 'defu'
 import type { NitroRouteConfig } from 'nitropack'
 import { readPackageJSON } from 'pkg-types'

--- a/src/util/i18n.ts
+++ b/src/util/i18n.ts
@@ -1,4 +1,4 @@
-import type { NuxtI18nOptions } from '@nuxtjs/i18n/dist/module'
+import type { NuxtI18nOptions } from '@nuxtjs/i18n'
 import type { Strategies } from 'vue-i18n-routing'
 import { joinURL } from 'ufo'
 import type { AutoI18nConfig, FilterInput } from '../runtime/types'


### PR DESCRIPTION
will be needed for next version of Nuxt as with Bundler module resolution importing from a path isn't allowed

https://github.com/nuxt/nuxt/pull/24837