### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,7 @@ Powerfully flexible XML Sitemaps that integrate seamlessly, for Nuxt. Previously
 1. Install `@nuxtjs/sitemap` dependency to your project:
 
 ```bash
-pnpm add -D @nuxtjs/sitemap
-#
-yarn add -D @nuxtjs/sitemap
-#
-npm install -D @nuxtjs/sitemap
+npx nuxi@latest module add sitemap
 ```
 
 2. Add it to your `modules` section in your `nuxt.config`:


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
