### PR TITLE
docs: remove `nuxt.config` section in Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,10 @@ Powerfully flexible XML Sitemaps that integrate seamlessly, for Nuxt. Previously
 
 💡 Using Nuxt 2? Use the [nuxt-community/sitemap-module](https://github.com/nuxt-community/sitemap-module) docs.
 
-1. Install `@nuxtjs/sitemap` dependency to your project:
+Install `@nuxtjs/sitemap` dependency to your project:
 
 ```bash
 npx nuxi@latest module add sitemap
-```
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ['@nuxtjs/sitemap']
-})
 ```
 
 # Documentation


### PR DESCRIPTION
## Linked Issue

related #258 

## Description

`nuxi module add` section has been added for `Nuxt Sitemap` in #258 issue.

`nuxt.config` is automatically added by Nuxi, so I removed (2).