### PR TITLE
fix: forward host header to dynamic source endpoint

### DIFF
--- a/src/runtime/nitro/sitemap/builder/sitemap.ts
+++ b/src/runtime/nitro/sitemap/builder/sitemap.ts
@@ -71,7 +71,7 @@ export async function buildSitemap(sitemap: SitemapDefinition, resolvers: NitroU
   // always fetch all sitemap data for the primary sitemap
   const sources = sitemap.includeAppSources ? await globalSitemapSources() : []
   sources.push(...await childSitemapSources(sitemap))
-  let resolvedSources = await resolveSitemapSources(sources)
+  let resolvedSources = await resolveSitemapSources(sources, resolvers.event)
   // normalise the sources for i18n
   if (autoI18n)
     resolvedSources = normaliseI18nSources(resolvedSources, { autoI18n, isI18nMapped, ...sitemap })


### PR DESCRIPTION
Try to get right host in danymic source eventhandler and give right right urls back.

It's useful in some saas platform with custom domain support, The sitemap need to be different for each Tenant