### PR TITLE
chore(ci): move renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>nuxt/renovate-config-nuxt"
-  ]
+  "extends": ["github>nuxt/renovate-config-nuxt"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>nuxt/renovate-config-nuxt"]
+  "extends": ["github>nuxt/renovate-config-nuxt"],
+  "packageRules": [
+    {
+      "groupName": "linter",
+      "groupSlug": "linter",
+      "matchPackageNames": ["@nuxt/eslint-config"],
+      "matchPackagePrefixes": ["eslint"]
+    }
+  ]
 }


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As with Nuxt Scripts, I moved the Renovate config to `.github/`.
  - nuxt/scripts#112

I also added configs for `eslint`, `eslint-plugin-*`, and `eslint-config-*`.
I think adding this rule will make it easier to merge library update PRs.