### PR TITLE
refactor: `import { type foo }` to `import type { foo }`

### DIFF
--- a/src/runtime/nitro/composables/defineSitemapEventHandler.ts
+++ b/src/runtime/nitro/composables/defineSitemapEventHandler.ts
@@ -1,4 +1,5 @@
-import { type EventHandlerRequest, type EventHandlerResponse, defineEventHandler } from 'h3'
+import { defineEventHandler } from 'h3'
+import type { EventHandlerRequest, EventHandlerResponse } from 'h3'
 import type { SitemapUrlInput } from '../../types'
 
 export const defineSitemapEventHandler: typeof defineEventHandler<EventHandlerRequest, EventHandlerResponse<SitemapUrlInput[]>> = defineEventHandler

--- a/src/runtime/nitro/sitemap/nitro.ts
+++ b/src/runtime/nitro/sitemap/nitro.ts
@@ -1,4 +1,5 @@
-import { type H3Event, getQuery, setHeader } from 'h3'
+import { getQuery, setHeader } from 'h3'
+import type { H3Event } from 'h3'
 import { fixSlashes } from 'site-config-stack/urls'
 import type { ModuleRuntimeConfig, NitroUrlResolvers, SitemapDefinition } from '../../types'
 import { buildSitemap } from './builder/sitemap'

--- a/src/runtime/nitro/sitemap/urlset/sources.ts
+++ b/src/runtime/nitro/sitemap/urlset/sources.ts
@@ -1,4 +1,5 @@
-import { type H3Event, getRequestHost } from 'h3'
+import { getRequestHost } from 'h3'
+import type { H3Event } from 'h3'
 import type { FetchError } from 'ofetch'
 import { defu } from 'defu'
 import type {

--- a/src/util/nuxtSitemap.ts
+++ b/src/util/nuxtSitemap.ts
@@ -5,7 +5,8 @@ import { useNuxt } from '@nuxt/kit'
 import { extname } from 'pathe'
 import { defu } from 'defu'
 import type { SitemapDefinition, SitemapUrl, SitemapUrlInput } from '../runtime/types'
-import { type CreateFilterOptions, createPathFilter } from '../runtime/utils-pure'
+import { createPathFilter } from '../runtime/utils-pure'
+import type { CreateFilterOptions } from '../runtime/utils-pure'
 
 export async function resolveUrls(urls: Required<SitemapDefinition>['urls']): Promise<SitemapUrlInput[]> {
   if (typeof urls === 'function')


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`import type { foo }` and `import { type foo }` were mixed, so I refactored it to `import type { foo }`.