### PR TITLE
test: additional extractSitemapMetaFromHtml coverage

### DIFF
--- a/test/unit/extractSitemapMetaFromHtml.test.ts
+++ b/test/unit/extractSitemapMetaFromHtml.test.ts
@@ -28,4 +28,59 @@ describe('extractSitemapMetaFromHtml', () => {
       }
     `)
   })
+
+  it('extracts images from HTML', async () => {
+    const mainTag = '<main>'
+    const mainClosingTag = '</main>'
+    const discoverableImageHTML = `
+      <img
+        src="https://res.cloudinary.com/dl6o1xpyq/image/upload/f_jpg,q_auto:best,dpr_auto,w_240,h_240/images/harlan-wilton"
+        alt="Harlan Wilton"
+      />
+    `
+    const excludeImageDataHTML = `
+      <img
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+      />
+    `
+    
+    const excludeImageBlobHTML = `
+      <img
+        src="blob:http://example.com/12345678-1234-5678-1234-567812345678"
+      />
+    `
+    const excludeImageFileHTML = `
+      <img
+        src="file:///C:/path/to/image.jpg"
+      />
+    `
+
+    // Test case 1 - Single discoverable image
+    const html1 = `${mainTag}${discoverableImageHTML}${mainClosingTag}`
+    const testcase1 = extractSitemapMetaFromHtml(html1)
+
+    expect(testcase1).toMatchInlineSnapshot(`
+      {
+        "images": [
+          {
+            "loc": "https://res.cloudinary.com/dl6o1xpyq/image/upload/f_jpg,q_auto:best,dpr_auto,w_240,h_240/images/harlan-wilton",
+          },
+        ],
+      }
+    `)
+
+    // Test case 2 - Single discoverable image with excluded image values
+    const html2 = `${mainTag}${discoverableImageHTML}${excludeImageDataHTML}${excludeImageBlobHTML}${excludeImageFileHTML}${mainClosingTag}`
+    const testcase2 = extractSitemapMetaFromHtml(html2)
+
+    expect(testcase2).toMatchInlineSnapshot(`
+      {
+        "images": [
+          {
+            "loc": "https://res.cloudinary.com/dl6o1xpyq/image/upload/f_jpg,q_auto:best,dpr_auto,w_240,h_240/images/harlan-wilton",
+          },
+        ],
+      }
+    `)
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

N/A

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Added additional unit test coverage for `extractSitemapMetaFromHtml()` extracting valid and invalid `<img>` elements.