### PR TITLE
feat: video discovery

### DIFF
--- a/.playground/nuxt.config.ts
+++ b/.playground/nuxt.config.ts
@@ -61,6 +61,7 @@ export default defineNuxtConfig({
       routes: [
         // '/sitemap_index.xml',
         '/prerender',
+        '/prerender-video',
         '/should-be-in-sitemap',
         '/foo.bar/',
         '/test.doc',

--- a/.playground/pages/prerender-video.vue
+++ b/.playground/pages/prerender-video.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div>
+    Pre-render Video Discovery Page
+
+    <!-- Control Video with src, should auto-discover -->
+    <video
+      controls
+      src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
+      poster="https://archive.org/download/BigBuckBunny_124/__ia_thumb.jpg"
+      width="620"
+      data-title="Big Buck Bunny"
+      data-description="Big Buck Bunny in DivX 720p."
+    >
+      Sorry, your browser doesn't support embedded videos, but don't worry, you
+      can
+      <a href="https://archive.org/details/BigBuckBunny_124">download it</a>
+      and watch it with your favorite video player!
+    </video>
+
+    <!-- Control Video with source, should auto-discover -->
+    <video
+      controls
+      poster="https://archive.org/download/DuckAndCover_185/__ia_thumb.jpg"
+      width="620"
+      data-title="Duck and Cover"
+      data-description="This film, a combination of animated cartoon and live action, shows young children what to do in case of an atomic attack."
+    >
+      <source
+        src="https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda_512kb.mp4"
+        type="video/mp4"
+      />
+      <source
+        src="https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda.avi"
+        type="video/x-msvideo"
+      />
+      Sorry, your browser doesn't support embedded videos, but don't worry, you
+      can
+      <a href="https://archive.org/details/DuckAndCover_185">download it</a>
+      and watch it with your favorite video player!
+    </video>
+  </div>
+</template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -59,6 +59,7 @@ export default defineNuxtModule<ModuleOptions>({
     defaultSitemapsChunkSize: 1000,
     autoLastmod: false,
     discoverImages: true,
+    discoverVideos: true,
     dynamicUrlsApiEndpoint: '/api/_sitemap-urls',
     urls: [],
     sortEntries: true,
@@ -458,6 +459,7 @@ declare module 'vue-router' {
       debug: config.debug,
       // needed for nuxt/content integration and prerendering
       discoverImages: config.discoverImages,
+      discoverVideos: config.discoverVideos,
 
       /* @nuxt/content */
       isNuxtContentDocumentDriven,

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -77,6 +77,7 @@ export function setupPrerenderHandler(options: ModuleRuntimeConfig, nuxt: Nuxt =
       }
       route._sitemap = defu(extractSitemapMetaFromHtml(html, {
         images: options.discoverImages,
+        videos: options.discoverVideos,
         // TODO configurable?
         lastmod: true,
         alternatives: true,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -76,6 +76,12 @@ export interface ModuleOptions extends SitemapDefinition {
    */
   discoverImages: boolean
   /**
+   * When prerendering, should videos be automatically be discovered and added to the sitemap.
+   *
+   * @default true
+   */
+  discoverVideos: boolean
+  /**
    * When chunking the sitemaps into multiple files, how many entries should each file contain.
    *
    * Set to `false` to disabling chunking completely.
@@ -193,7 +199,7 @@ export interface AutoI18nConfig {
   strategy: 'prefix' | 'prefix_except_default' | 'prefix_and_default' | 'no_prefix'
 }
 
-export interface ModuleRuntimeConfig extends Pick<ModuleOptions, 'cacheMaxAgeSeconds' | 'sitemapName' | 'excludeAppSources' | 'sortEntries' | 'defaultSitemapsChunkSize' | 'xslColumns' | 'xslTips' | 'debug' | 'discoverImages' | 'autoLastmod' | 'xsl' | 'credits' > {
+export interface ModuleRuntimeConfig extends Pick<ModuleOptions, 'cacheMaxAgeSeconds' | 'sitemapName' | 'excludeAppSources' | 'sortEntries' | 'defaultSitemapsChunkSize' | 'xslColumns' | 'xslTips' | 'debug' | 'discoverImages' | 'discoverVideos' | 'autoLastmod' | 'xsl' | 'credits' > {
   version: string
   isNuxtContentDocumentDriven: boolean
   sitemaps: { index?: Pick<SitemapDefinition, 'sitemapName' | '_route'> & { sitemaps: SitemapIndexEntry[] } } & Record<string, Omit<SitemapDefinition, 'urls'> & { _hasSourceChunk?: boolean }>

--- a/test/unit/extractSitemapMetaFromHtml.test.ts
+++ b/test/unit/extractSitemapMetaFromHtml.test.ts
@@ -43,7 +43,7 @@ describe('extractSitemapMetaFromHtml', () => {
         src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
       />
     `
-    
+
     const excludeImageBlobHTML = `
       <img
         src="blob:http://example.com/12345678-1234-5678-1234-567812345678"
@@ -78,6 +78,191 @@ describe('extractSitemapMetaFromHtml', () => {
         "images": [
           {
             "loc": "https://res.cloudinary.com/dl6o1xpyq/image/upload/f_jpg,q_auto:best,dpr_auto,w_240,h_240/images/harlan-wilton",
+          },
+        ],
+      }
+    `)
+  })
+
+  it('extracts videos from HTML', async () => {
+    const mainTag = '<main>'
+    const mainClosingTag = '</main>'
+    const discoverableVideoSrcHTML = `
+      <video
+        controls
+        src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
+        width="620"
+      >
+        Sorry, your browser doesn't support embedded videos, but don't worry, you
+        can
+        <a href="https://archive.org/details/BigBuckBunny_124">download it</a>
+        and watch it with your favorite video player!
+      </video>
+    `
+
+    const discoverableVideoWithPosterSrcHTML = `
+      <video
+        controls
+        src="https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4"
+        poster="https://archive.org/download/BigBuckBunny_124/__ia_thumb.jpg"
+        width="620"
+        data-title="Big Buck Bunny"
+        data-description="Big Buck Bunny in DivX 720p."
+      >
+        Sorry, your browser doesn't support embedded videos, but don't worry, you
+        can
+        <a href="https://archive.org/details/BigBuckBunny_124">download it</a>
+        and watch it with your favorite video player!
+      </video>
+    `
+
+    const discoverableVideoSourcesHTML = `
+      <video
+        controls
+        width="620"
+      >
+        <source
+          src="https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda_512kb.mp4"
+          type="video/mp4"
+        />
+        <source
+          src="https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda.avi"
+          type="video/x-msvideo"
+        />
+        Sorry, your browser doesn't support embedded videos, but don't worry, you
+        can
+        <a href="https://archive.org/details/DuckAndCover_185">download it</a>
+        and watch it with your favorite video player!
+      </video>
+    `
+
+    const discoverableVideoSourcesWithPosterHTML = `
+      <video
+        controls
+        poster="https://archive.org/download/DuckAndCover_185/__ia_thumb.jpg"
+        width="620"
+        data-title="Duck and Cover"
+        data-description="This film, a combination of animated cartoon and live action, shows young children what to do in case of an atomic attack."
+      >
+        <source
+          src="https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda_512kb.mp4"
+          type="video/mp4"
+        />
+        <source
+          src="https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda.avi"
+          type="video/x-msvideo"
+        />
+        Sorry, your browser doesn't support embedded videos, but don't worry, you
+        can
+        <a href="https://archive.org/details/DuckAndCover_185">download it</a>
+        and watch it with your favorite video player!
+      </video>
+    `
+
+    // Test case 1 - Single discoverable video src element
+    const html1 = `${mainTag}${discoverableVideoSrcHTML}${mainClosingTag}`
+    const testcase1 = extractSitemapMetaFromHtml(html1)
+
+    expect(testcase1).toMatchInlineSnapshot(`
+      {
+        "videos": [
+          {
+            "content_loc": "https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4",
+            "description": "",
+            "thumbnail_loc": "",
+            "title": "",
+          },
+        ],
+      }
+    `)
+
+    // Test case 2 - Single discoverable video src element with poster
+    const html2 = `${mainTag}${discoverableVideoWithPosterSrcHTML}${mainClosingTag}`
+    const testcase2 = extractSitemapMetaFromHtml(html2)
+
+    expect(testcase2).toMatchInlineSnapshot(`
+      {
+        "videos": [
+          {
+            "content_loc": "https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4",
+            "description": "Big Buck Bunny in DivX 720p.",
+            "thumbnail_loc": "https://archive.org/download/BigBuckBunny_124/__ia_thumb.jpg",
+            "title": "Big Buck Bunny",
+          },
+        ],
+      }
+    `)
+
+    // Test case 3 - Multiple discoverable video sources
+    const html3 = `${mainTag}${discoverableVideoSourcesHTML}${mainClosingTag}`
+    const testcase3 = extractSitemapMetaFromHtml(html3)
+
+    expect(testcase3).toMatchInlineSnapshot(`
+      {
+        "videos": [
+          {
+            "content_loc": "https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda_512kb.mp4",
+            "description": "",
+            "thumbnail_loc": "",
+            "title": "",
+          },
+          {
+            "content_loc": "https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda.avi",
+            "description": "",
+            "thumbnail_loc": "",
+            "title": "",
+          },
+        ],
+      }
+    `);
+
+    // Test case 4 - Multiple discoverable video sources
+    const html4 = `${mainTag}${discoverableVideoSourcesWithPosterHTML}${mainClosingTag}`;
+    const testcase4 = extractSitemapMetaFromHtml(html4);
+
+    expect(testcase4).toMatchInlineSnapshot(`
+      {
+        "videos": [
+          {
+            "content_loc": "https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda_512kb.mp4",
+            "description": "This film, a combination of animated cartoon and live action, shows young children what to do in case of an atomic attack.",
+            "thumbnail_loc": "https://archive.org/download/DuckAndCover_185/__ia_thumb.jpg",
+            "title": "Duck and Cover",
+          },
+          {
+            "content_loc": "https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda.avi",
+            "description": "This film, a combination of animated cartoon and live action, shows young children what to do in case of an atomic attack.",
+            "thumbnail_loc": "https://archive.org/download/DuckAndCover_185/__ia_thumb.jpg",
+            "title": "Duck and Cover",
+          },
+        ],
+      }
+    `)
+
+    // Test case 4 - Mixture of single video src and multiple discoverable video sources
+    const html5 = `${mainTag}${discoverableVideoWithPosterSrcHTML}${discoverableVideoSourcesWithPosterHTML}${mainClosingTag}`
+    const testcase5 = extractSitemapMetaFromHtml(html5)
+
+    expect(testcase5).toMatchInlineSnapshot(`
+      {
+        "videos": [
+          {
+            "content_loc": "https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.mp4",
+            "description": "Big Buck Bunny in DivX 720p.",
+            "thumbnail_loc": "https://archive.org/download/BigBuckBunny_124/__ia_thumb.jpg",
+            "title": "Big Buck Bunny",
+          },
+          {
+            "content_loc": "https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda_512kb.mp4",
+            "description": "This film, a combination of animated cartoon and live action, shows young children what to do in case of an atomic attack.",
+            "thumbnail_loc": "https://archive.org/download/DuckAndCover_185/__ia_thumb.jpg",
+            "title": "Duck and Cover",
+          },
+          {
+            "content_loc": "https://archive.org/download/DuckAndCover_185/CivilDefenseFilm-DuckAndCoverColdWarNuclearPropaganda.avi",
+            "description": "This film, a combination of animated cartoon and live action, shows young children what to do in case of an atomic attack.",
+            "thumbnail_loc": "https://archive.org/download/DuckAndCover_185/__ia_thumb.jpg",
+            "title": "Duck and Cover",
           },
         ],
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#299

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

- Added `discoverVideo` functionality to discover `<video>` tags in pre-rendered content. 
- Extended functionality of `extractSitemapMetaFromHtml` to extract attributes from `<video>` to provide required values for video sitemap(s). 
- Added tests to cover new `extractSitemapMetaFromHtml` functionality.

Example: screenshots below show the HTML and what the expected sitemap results would be. 

![Screenshot 2024-06-28 at 22 49 55](https://github.com/nuxt-modules/sitemap/assets/16214725/febba342-d725-4e45-baf5-c7221f673f87)

![Screenshot 2024-06-28 at 22 49 40](https://github.com/nuxt-modules/sitemap/assets/16214725/a36b7706-9e0d-4b6b-8b64-7f24aad21954)

### Considerations

- `discoverVideos` is enabled by default to be consistent with `discoverImages` option.
- Required video sitemap tags (`thumbnail_loc`, `title`, `description`, `content_loc`) will return empty string in the event there are no value provided for that attribute. Google recommended these tags are 'required'.
- `src/runtime/nitro/plugins/nuxt-content.ts` will search only top-level `<video src="...>`. I'll be honest I wasn't totally sure of this functionality I simply mimicked `discoverImage`. Happy to provide additional changes.