### PR TITLE
feat!: new multi sitemaps paths

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -397,7 +397,7 @@ declare module 'vue-router' {
         middleware: false,
       })
       addServerHandler({
-        route: `/sitemap/:sitemap`,
+        route: `/sitemap/**:sitemap`,
         handler: resolve('./runtime/nitro/routes/sitemap/[sitemap].xml'),
         lazy: true,
         middleware: false,

--- a/src/module.ts
+++ b/src/module.ts
@@ -318,8 +318,10 @@ declare module 'vue-router' {
       nuxt.options.nitro.routeRules['/sitemap.xml'] = { redirect: '/sitemap_index.xml' }
       nuxt.options.nitro.routeRules['/sitemap_index.xml'] = routeRules
       if (typeof config.sitemaps === 'object') {
-        for (const k in config.sitemaps)
+        for (const k in config.sitemaps) {
           nuxt.options.nitro.routeRules[`/sitemap/${k}.xml`] = routeRules
+          nuxt.options.nitro.routeRules[`/${k}-sitemap.xml`] = { redirect: `/sitemap/${k}.xml` }
+        }
       }
       else {
         // TODO we should support the chunked generated sitemap names

--- a/src/module.ts
+++ b/src/module.ts
@@ -397,8 +397,8 @@ declare module 'vue-router' {
         middleware: false,
       })
       addServerHandler({
-        route: `/sitemaps/:$1`,
-        handler: resolve('./runtime/nitro/routes/sitemaps/[sitemap].xml'),
+        route: `/sitemap/:sitemap`,
+        handler: resolve('./runtime/nitro/routes/sitemap/[sitemap].xml'),
         lazy: true,
         middleware: false,
       })
@@ -416,7 +416,7 @@ declare module 'vue-router' {
           sitemaps[sitemapName as keyof typeof sitemaps] = defu(
             {
               sitemapName,
-              _route: withBase(`sitemaps/${sitemapName}.xml`, nuxt.options.app.baseURL || '/'),
+              _route: withBase(`sitemap/${sitemapName}.xml`, nuxt.options.app.baseURL || '/'),
               _hasSourceChunk: typeof definition.urls !== 'undefined' || definition.sources?.length || !!definition.dynamicUrlsApiEndpoint,
             },
             { ...definition, urls: undefined, sources: undefined },

--- a/src/runtime/nitro/routes/sitemap.xsl.ts
+++ b/src/runtime/nitro/routes/sitemap.xsl.ts
@@ -19,7 +19,8 @@ export default defineEventHandler(async (e) => {
   const { name: siteName, url: siteUrl } = useSiteConfig(e)
 
   const referrer = getHeader(e, 'Referer')! || '/'
-  const isNotIndexButHasIndex = referrer !== fixPath('/sitemap.xml') && parseURL(referrer).pathname.endsWith('-sitemap.xml')
+  const referrerPath = parseURL(referrer).pathname
+  const isNotIndexButHasIndex = referrerPath !== '/sitemap.xml' && referrerPath !== '/sitemap_index.xml' && referrerPath.endsWith('.xml')
   const sitemapName = parseURL(referrer).pathname.split('/').pop()?.split('-sitemap')[0] || fallbackSitemapName
   const title = `${siteName}${sitemapName !== 'sitemap.xml' ? ` - ${sitemapName === 'sitemap_index.xml' ? 'index' : sitemapName}` : ''}`.replace(/&/g, '&amp;')
 

--- a/src/runtime/nitro/routes/sitemap/[sitemap].xml.ts
+++ b/src/runtime/nitro/routes/sitemap/[sitemap].xml.ts
@@ -6,7 +6,8 @@ export default defineEventHandler(async (e) => {
   const runtimeConfig = useSimpleSitemapRuntimeConfig(e)
   const { sitemaps } = runtimeConfig
 
-  const sitemapName = getRouterParam(e, 'sitemap')?.replace('.xml', '')
+  const sitemapName = (getRouterParam(e, 'sitemap') || e.path)?.replace('.xml', '')
+    .replace('/sitemap/', '')
   // check if sitemapName can be cast to a number safely
   const isChunking = typeof sitemaps.chunks !== 'undefined' && !Number.isNaN(Number(sitemapName))
   if (!sitemapName || (!(sitemapName in sitemaps) && !isChunking)) {

--- a/src/runtime/nitro/routes/sitemap/[sitemap].xml.ts
+++ b/src/runtime/nitro/routes/sitemap/[sitemap].xml.ts
@@ -1,4 +1,4 @@
-import { createError, defineEventHandler } from 'h3'
+import { createError, defineEventHandler, getRouterParam } from 'h3'
 import { useSimpleSitemapRuntimeConfig } from '../../utils'
 import { createSitemap } from '../../sitemap/nitro'
 
@@ -6,7 +6,7 @@ export default defineEventHandler(async (e) => {
   const runtimeConfig = useSimpleSitemapRuntimeConfig(e)
   const { sitemaps } = runtimeConfig
 
-  const sitemapName = e.context.params?.sitemap
+  const sitemapName = getRouterParam(e, 'sitemap')?.replace('.xml', '')
   // check if sitemapName can be cast to a number safely
   const isChunking = typeof sitemaps.chunks !== 'undefined' && !Number.isNaN(Number(sitemapName))
   if (!sitemapName || (!(sitemapName in sitemaps) && !isChunking)) {

--- a/src/runtime/nitro/routes/sitemap_index.xml.ts
+++ b/src/runtime/nitro/routes/sitemap_index.xml.ts
@@ -2,7 +2,7 @@ import { appendHeader, defineEventHandler, setHeader } from 'h3'
 import { useSimpleSitemapRuntimeConfig } from '../utils'
 import { buildSitemapIndex, urlsToIndexXml } from '../sitemap/builder/sitemap-index'
 import type { SitemapOutputHookCtx } from '../../types'
-import { useNitroUrlResolvers } from '..//sitemap/nitro'
+import { useNitroUrlResolvers } from '../sitemap/nitro'
 import { useNitroApp } from '#imports'
 
 export default defineEventHandler(async (e) => {
@@ -18,7 +18,7 @@ export default defineEventHandler(async (e) => {
       e,
       'x-nitro-prerender',
       sitemaps.filter(entry => !!entry._sitemapName)
-        .map(entry => encodeURIComponent(`/${entry._sitemapName}-sitemap.xml`)).join(', '),
+        .map(entry => encodeURIComponent(`/sitemap/${entry._sitemapName}.xml`)).join(', '),
     )
   }
 

--- a/src/runtime/nitro/routes/sitemaps/[sitemap].xml.ts
+++ b/src/runtime/nitro/routes/sitemaps/[sitemap].xml.ts
@@ -1,22 +1,15 @@
 import { createError, defineEventHandler } from 'h3'
-import { parseURL } from 'ufo'
-import { useSimpleSitemapRuntimeConfig } from '../utils'
-import { createSitemap } from '../sitemap/nitro'
+import { useSimpleSitemapRuntimeConfig } from '../../utils'
+import { createSitemap } from '../../sitemap/nitro'
 
 export default defineEventHandler(async (e) => {
-  const path = parseURL(e.path).pathname
-  if (!path.endsWith('-sitemap.xml'))
-    return
-
-  const runtimeConfig = useSimpleSitemapRuntimeConfig()
+  const runtimeConfig = useSimpleSitemapRuntimeConfig(e)
   const { sitemaps } = runtimeConfig
 
-  const sitemapName = path
-    .replace('-sitemap.xml', '')
-    .replace('/', '')
+  const sitemapName = e.context.params?.sitemap
   // check if sitemapName can be cast to a number safely
   const isChunking = typeof sitemaps.chunks !== 'undefined' && !Number.isNaN(Number(sitemapName))
-  if (!(sitemapName in sitemaps) && !isChunking) {
+  if (!sitemapName || (!(sitemapName in sitemaps) && !isChunking)) {
     return createError({
       statusCode: 404,
       message: `Sitemap "${sitemapName}" not found.`,

--- a/src/runtime/nitro/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/nitro/sitemap/builder/sitemap-index.ts
@@ -64,7 +64,7 @@ export async function buildSitemapIndex(resolvers: NitroUrlResolvers, runtimeCon
     const sitemap = chunks[name]
     const entry: SitemapIndexEntry = {
       _sitemapName: name,
-      sitemap: resolvers.canonicalUrlResolver(`sitemaps/${name}.xml`),
+      sitemap: resolvers.canonicalUrlResolver(`sitemap/${name}.xml`),
     }
     let lastmod = sitemap.urls
       .filter(a => !!a?.lastmod)

--- a/src/runtime/nitro/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/nitro/sitemap/builder/sitemap-index.ts
@@ -64,7 +64,7 @@ export async function buildSitemapIndex(resolvers: NitroUrlResolvers, runtimeCon
     const sitemap = chunks[name]
     const entry: SitemapIndexEntry = {
       _sitemapName: name,
-      sitemap: resolvers.canonicalUrlResolver(`${name}-sitemap.xml`),
+      sitemap: resolvers.canonicalUrlResolver(`sitemaps/${name}.xml`),
     }
     let lastmod = sitemap.urls
       .filter(a => !!a?.lastmod)

--- a/src/runtime/nitro/sitemap/nitro.ts
+++ b/src/runtime/nitro/sitemap/nitro.ts
@@ -33,19 +33,19 @@ export function useNitroUrlResolvers(e: H3Event): NitroUrlResolvers {
   }
 }
 
-export async function createSitemap(e: H3Event, definition: SitemapDefinition, runtimeConfig: ModuleRuntimeConfig) {
+export async function createSitemap(event: H3Event, definition: SitemapDefinition, runtimeConfig: ModuleRuntimeConfig) {
   const { sitemapName } = definition
   const nitro = useNitroApp()
-  const resolvers = useNitroUrlResolvers(e)
+  const resolvers = useNitroUrlResolvers(event)
   let sitemapUrls = await buildSitemapUrls(definition, resolvers, runtimeConfig)
 
   const routeRuleMatcher = createNitroRouteRuleMatcher()
   const { autoI18n } = runtimeConfig
-  sitemapUrls = sitemapUrls.map((e) => {
-    // blocked by nuxt-simple-robots (this is a polyfill if not installed)
-    if (!getPathRobotConfig(e, { path: e._path.pathname, skipSiteIndexable: true }).indexable)
+  sitemapUrls = sitemapUrls.map((u) => {
+    const path = u._path?.pathname || u.loc
+    // blocked by @nuxtjs/robots (this is a polyfill if not installed)
+    if (!getPathRobotConfig(event, { path, skipSiteIndexable: true }).indexable)
       return false
-    const path = e._path.pathname
     let routeRules = routeRuleMatcher(path)
     // apply top-level path without prefix, users can still target the localed path
     if (autoI18n?.locales && autoI18n?.strategy !== 'no_prefix') {
@@ -66,7 +66,7 @@ export async function createSitemap(e: H3Event, definition: SitemapDefinition, r
     if (routeRules.redirect || hasRobotsDisabled)
       return false
 
-    return routeRules.sitemap ? defu(e, routeRules.sitemap) as ResolvedSitemapUrl : e
+    return routeRules.sitemap ? defu(u, routeRules.sitemap) as ResolvedSitemapUrl : u
   }).filter(Boolean)
 
   // 6. nitro hooks
@@ -84,11 +84,11 @@ export async function createSitemap(e: H3Event, definition: SitemapDefinition, r
   const ctx = { sitemap, sitemapName }
   await nitro.hooks.callHook('sitemap:output', ctx)
   // need to clone the config object to make it writable
-  setHeader(e, 'Content-Type', 'text/xml; charset=UTF-8')
+  setHeader(event, 'Content-Type', 'text/xml; charset=UTF-8')
   if (runtimeConfig.cacheMaxAgeSeconds)
-    setHeader(e, 'Cache-Control', `public, max-age=${runtimeConfig.cacheMaxAgeSeconds}, must-revalidate`)
+    setHeader(event, 'Cache-Control', `public, max-age=${runtimeConfig.cacheMaxAgeSeconds}, must-revalidate`)
   else
-    setHeader(e, 'Cache-Control', `no-cache, no-store`)
-  e.context._isSitemap = true
+    setHeader(event, 'Cache-Control', `no-cache, no-store`)
+  event.context._isSitemap = true
   return ctx.sitemap
 }

--- a/src/runtime/nitro/sitemap/nitro.ts
+++ b/src/runtime/nitro/sitemap/nitro.ts
@@ -58,8 +58,12 @@ export async function createSitemap(event: H3Event, definition: SitemapDefinitio
 
     if (routeRules.sitemap === false)
       return false
-    if (typeof routeRules.index !== 'undefined' && !routeRules.index)
+    if ((typeof routeRules.index !== 'undefined' && !routeRules.index)
+      // @ts-expect-error runtime types
+      || (typeof routeRules.robots !== 'undefined' && !routeRules.robots)
+    ) {
       return false
+    }
     const hasRobotsDisabled = Object.entries(routeRules.headers || {})
       .some(([name, value]) => name.toLowerCase() === 'x-robots-tag' && value.toLowerCase().includes('noindex'))
     // check for redirects and headers which aren't indexable

--- a/test/integration/chunks/default.ts
+++ b/test/integration/chunks/default.ts
@@ -17,20 +17,20 @@ describe('multi chunks', () => {
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
       <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
           <sitemap>
-              <loc>https://nuxtseo.com/0-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/0.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/1-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/1.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/2-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/2.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/3-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/3.xml</loc>
           </sitemap>
       </sitemapindex>"
     `)
-    const sitemap0 = await $fetch('/0-sitemap.xml')
+    const sitemap0 = await $fetch('/sitemap/0.xml')
     expect(sitemap0).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
       <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/test/integration/chunks/generate.test.ts
+++ b/test/integration/chunks/generate.test.ts
@@ -27,20 +27,20 @@ describe('generate', () => {
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
       <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
           <sitemap>
-              <loc>https://nuxtseo.com/0-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/0.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/1-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/1.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/2-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/2.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/3-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/3.xml</loc>
           </sitemap>
       </sitemapindex>"
     `)
-    const sitemapEn = (await readFile(resolve(rootDir, '.output/public/0-sitemap.xml'), 'utf-8')).replace(/lastmod>(.*?)</g, 'lastmod><')
+    const sitemapEn = (await readFile(resolve(rootDir, '.output/public/sitemap/0.xml'), 'utf-8')).replace(/lastmod>(.*?)</g, 'lastmod><')
     expect(sitemapEn).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
       <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/test/integration/i18n/domains.test.ts
+++ b/test/integration/i18n/domains.test.ts
@@ -41,18 +41,18 @@ describe('i18n domains', () => {
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
       <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
           <sitemap>
-              <loc>https://nuxtseo.com/en-US-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/en-US.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/es-ES-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/es-ES.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/fr-FR-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/fr-FR.xml</loc>
           </sitemap>
       </sitemapindex>"
     `)
 
-    const fr = await $fetch('/fr-FR-sitemap.xml')
+    const fr = await $fetch('/sitemap/fr-FR.xml')
     expect(fr).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
       <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/test/integration/i18n/dynamic-urls.test.ts
+++ b/test/integration/i18n/dynamic-urls.test.ts
@@ -24,7 +24,7 @@ await setup({
 })
 describe('i18n dynamic urls', () => {
   it('basic', async () => {
-    let sitemap = await $fetch('/en-US-sitemap.xml')
+    let sitemap = await $fetch('/sitemap/en-US.xml')
 
     // strip lastmod
     sitemap = sitemap.replace(/<lastmod>.*<\/lastmod>/g, '')

--- a/test/integration/i18n/filtering-include.test.ts
+++ b/test/integration/i18n/filtering-include.test.ts
@@ -19,7 +19,7 @@ await setup({
 })
 describe('i18n filtering with include', () => {
   it('basic', async () => {
-    const sitemap = await $fetch('/main-sitemap.xml')
+    const sitemap = await $fetch('/sitemap/main.xml')
 
     expect(sitemap).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>

--- a/test/integration/i18n/filtering-regexp.test.ts
+++ b/test/integration/i18n/filtering-regexp.test.ts
@@ -21,7 +21,7 @@ await setup({
 })
 describe('i18n filtering with regexp', () => {
   it('basic', async () => {
-    let sitemap = await $fetch('/en-US-sitemap.xml')
+    let sitemap = await $fetch('/sitemap/en-US.xml')
 
     // strip lastmod
     sitemap = sitemap.replace(/<lastmod>.*<\/lastmod>/g, '')

--- a/test/integration/i18n/filtering.test.ts
+++ b/test/integration/i18n/filtering.test.ts
@@ -16,7 +16,7 @@ await setup({
 })
 describe('i18n filtering', () => {
   it('basic', async () => {
-    let sitemap = await $fetch('/en-US-sitemap.xml')
+    let sitemap = await $fetch('/sitemap/en-US.xml')
 
     // strip lastmod
     sitemap = sitemap.replace(/<lastmod>.*<\/lastmod>/g, '')

--- a/test/integration/i18n/generate.test.ts
+++ b/test/integration/i18n/generate.test.ts
@@ -37,7 +37,7 @@ describe('generate', () => {
           </sitemap>
       </sitemapindex>"
     `)
-    const sitemapEn = (await readFile(resolve(rootDir, '.output/public/en-US-sitemap.xml'), 'utf-8')).replace(/lastmod>(.*?)</g, 'lastmod><')
+    const sitemapEn = (await readFile(resolve(rootDir, '.output/public/sitemap/en-US.xml'), 'utf-8')).replace(/lastmod>(.*?)</g, 'lastmod><')
     expect(sitemapEn).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
       <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/test/integration/i18n/generate.test.ts
+++ b/test/integration/i18n/generate.test.ts
@@ -27,13 +27,13 @@ describe('generate', () => {
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
       <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
           <sitemap>
-              <loc>https://nuxtseo.com/en-US-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/en-US.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/es-ES-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/es-ES.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/fr-FR-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/fr-FR.xml</loc>
           </sitemap>
       </sitemapindex>"
     `)

--- a/test/integration/i18n/pages-multi.test.ts
+++ b/test/integration/i18n/pages-multi.test.ts
@@ -74,6 +74,54 @@ describe('i18n pages multi', () => {
       </sitemapindex>"
     `)
     const fr = await $fetch('/sitemap/fr-FR.xml')
-    expect(fr).toMatchInlineSnapshot()
+    expect(fr).toMatchInlineSnapshot(`
+      "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
+      <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url>
+              <loc>https://nuxtseo.com/fr/a-propos</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/about" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/a-propos" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/about" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/__sitemap/url</loc>
+              <changefreq>weekly</changefreq>
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/__sitemap/url" />
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/__sitemap/url" />
+              <xhtml:link rel="alternate" hreflang="es-ES" href="https://nuxtseo.com/es/__sitemap/url" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/__sitemap/url" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres/developement</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/development" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/developement" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/development" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres/formation</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/coaching" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/formation" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/coaching" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres/developement/app</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/development/app" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/developement/app" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/development/app" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres/developement/site-web</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/development/website" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/developement/site-web" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/development/website" />
+          </url>
+      </urlset>"
+    `)
   }, 60000)
 })

--- a/test/integration/i18n/pages-multi.test.ts
+++ b/test/integration/i18n/pages-multi.test.ts
@@ -6,13 +6,22 @@ const { resolve } = createResolver(import.meta.url)
 
 await setup({
   rootDir: resolve('../../fixtures/i18n'),
-  build: true,
   server: true,
   nuxtConfig: {
     i18n: {
       locales: [
-        'en',
-        'fr',
+        {
+          code: 'en',
+          iso: 'en-US',
+        },
+        {
+          code: 'es',
+          iso: 'es-ES',
+        },
+        {
+          code: 'fr',
+          iso: 'fr-FR',
+        },
       ],
       pages: {
         'about': {
@@ -49,84 +58,22 @@ await setup({
 })
 describe('i18n pages multi', () => {
   it('basic', async () => {
-    const index = await $fetch('/sitemap.xml')
+    const index = await $fetch('/sitemap_index.xml')
     expect(index).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
       <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
           <sitemap>
-              <loc>https://nuxtseo.com/en-US-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/en-US.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/fr-FR-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/es-ES.xml</loc>
           </sitemap>
           <sitemap>
-              <loc>https://nuxtseo.com/es-ES-sitemap.xml</loc>
+              <loc>https://nuxtseo.com/sitemap/fr-FR.xml</loc>
           </sitemap>
       </sitemapindex>"
     `)
-    const fr = await $fetch('/fr-FR-sitemap.xml')
-    expect(fr).toMatchInlineSnapshot(`
-      "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
-      <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-          <url>
-              <loc>https://nuxtseo.com/fr/a-propos</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/about" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/a-propos" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/about" />
-          </url>
-          <url>
-              <loc>https://nuxtseo.com/fr/offres</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services" />
-          </url>
-          <url>
-              <loc>https://nuxtseo.com/fr/__sitemap/url</loc>
-              <changefreq>weekly</changefreq>
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/__sitemap/url" />
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/__sitemap/url" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/__sitemap/url" />
-              <xhtml:link rel="alternate" hreflang="es-ES" href="https://nuxtseo.com/es/__sitemap/url" />
-          </url>
-          <url>
-              <loc>https://nuxtseo.com/fr/offres/developement</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/development" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/developement" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/development" />
-          </url>
-          <url>
-              <loc>https://nuxtseo.com/fr/offres/formation</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/coaching" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/formation" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/coaching" />
-          </url>
-          <url>
-              <loc>https://nuxtseo.com/fr/offres/developement/app</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/development/app" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/developement/app" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/development/app" />
-          </url>
-          <url>
-              <loc>https://nuxtseo.com/fr/offres/developement/site-web</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/development/website" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/developement/site-web" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/development/website" />
-          </url>
-      </urlset>"
-    `)
-    const es = await $fetch('/es-ES-sitemap.xml')
-    expect(es).toMatchInlineSnapshot(`
-      "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
-      <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-          <url>
-              <loc>https://nuxtseo.com/es/__sitemap/url</loc>
-              <changefreq>weekly</changefreq>
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/__sitemap/url" />
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/__sitemap/url" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/__sitemap/url" />
-              <xhtml:link rel="alternate" hreflang="es-ES" href="https://nuxtseo.com/es/__sitemap/url" />
-          </url>
-      </urlset>"
-    `)
+    const fr = await $fetch('/sitemap/fr-FR.xml')
+    expect(fr).toMatchInlineSnapshot()
   }, 60000)
 })

--- a/test/integration/multi/defaults.ts
+++ b/test/integration/multi/defaults.ts
@@ -36,7 +36,7 @@ await setup({
 })
 describe('mutli defaults', () => {
   it('basic', async () => {
-    let sitemap = await $fetch('/foo-sitemap.xml')
+    let sitemap = await $fetch('/sitemap/foo.xml')
     // remove lastmods before tresting
     sitemap = sitemap.replace(/lastmod>(.*?)</g, 'lastmod><')
     // basic test to make sure we get a valid response

--- a/test/integration/multi/endpoints.ts
+++ b/test/integration/multi/endpoints.ts
@@ -25,7 +25,7 @@ await setup({
 })
 describe('multi endpoints', () => {
   it('basic', async () => {
-    let sitemap = await $fetch('/foo-sitemap.xml')
+    let sitemap = await $fetch('/sitemap/foo.xml')
     // remove lastmods before tresting
     sitemap = sitemap.replace(/lastmod>(.*?)</g, 'lastmod><')
     // basic test to make sure we get a valid response

--- a/test/integration/multi/filtering.test.ts
+++ b/test/integration/multi/filtering.test.ts
@@ -36,7 +36,7 @@ await setup({
 })
 describe('multi filtering', () => {
   it('basic', async () => {
-    let sitemap = await $fetch('/foo-sitemap.xml')
+    let sitemap = await $fetch('/sitemap/foo.xml')
 
     // strip lastmod
     sitemap = sitemap.replace(/<lastmod>.*<\/lastmod>/g, '')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
n/a

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently supporting multi-support is done through explicit build-time routes or using a middleware if they're chunked. This blocks us from generating runtime sitemaps when not chunking, as the paths are registered. This is an issue for multi-tenancy apps and is blocking https://github.com/nuxt-modules/sitemap/issues/265.

The paths change from `/{name}-sitemap.xml` to `/sitemap/{name}.xml` and are handled by Nitro named routes.

:warning: This is a breaking change if users have registered the multi-sitemap paths in Google Search Console, users should update these when upgrading.

- [x] Add redirects from old sitemap to new for v6 major 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
