### PR TITLE
fix(module): prevent false positive warning about ignored root keys

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -113,15 +113,18 @@ export default defineNuxtModule<ModuleOptions>({
       const isSitemapIndexOnly = typeof normalizedSitemaps?.index !== 'undefined' && Object.keys(normalizedSitemaps).length === 1
       if (!isSitemapIndexOnly) {
         // if the user is doing multi-sitempas using the sitemaps config, we warn when root keys are used as they won't do anything
-        const invalidRootKeys = [
-          'includeAppSources',
-          'sources',
-        ]
-        for (const key of invalidRootKeys) {
-          if (Object.keys(config).includes(key)) {
-            logger.warn(`You are using multiple-sitemaps but have provided \`sitemap.${key}\` in your Nuxt config. This will be ignored, please move it to the child sitemap config.`)
-            logger.warn('Learn more at: https://nuxtseo.com/sitemap/guides/multi-sitemaps')
-          }
+        const warnForIgnoredKey = (key: string) => {
+          logger.warn(`You are using multiple-sitemaps but have provided \`sitemap.${key}\` in your Nuxt config. This will be ignored, please move it to the child sitemap config.`)
+          logger.warn('Learn more at: https://nuxtseo.com/sitemap/guides/multi-sitemaps')
+        }
+
+        switch (true) {
+          case config?.sources?.length !== 0:
+            warnForIgnoredKey('sources')
+            break
+          case config?.includeAppSources !== undefined:
+            warnForIgnoredKey('includeAppSources')
+            break
         }
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue

Resolved #332

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

At module startup, when using the multiple sitemaps feature, currently you will recieve a false positive warning about using root config keys that will be ignored. Even though if you haven't defined them. This was because the check was an Object.keys(config).includes() which always returns true since the module `config` object is filled with default data.

Fixing this by changing the check to test if the values differ from the default ones.
