### PR TITLE
fix(i18n): reverse only locales logic

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -36,7 +36,7 @@ import { includesSitemapRoot, isNuxtGenerate, setupPrerenderHandler } from './pr
 import { mergeOnKey } from './runtime/utils-pure'
 import { setupDevToolsUI } from './devtools'
 import { normaliseDate } from './runtime/nitro/sitemap/urlset/normalise'
-import { generatePathForI18nPages, getExcludedLocalesFromI18nConfig, splitPathForI18nLocales } from './util/i18n'
+import { generatePathForI18nPages, getOnlyLocalesFromI18nConfig, splitPathForI18nLocales } from './util/i18n'
 import { normalizeFilters } from './util/filter'
 
 export interface ModuleOptions extends _ModuleOptions {}
@@ -163,8 +163,11 @@ export default defineNuxtModule<ModuleOptions>({
       if (!await hasNuxtModuleCompatibility('@nuxtjs/i18n', '>=8'))
         logger.warn(`You are using @nuxtjs/i18n v${i18nVersion}. For the best compatibility, please upgrade to @nuxtjs/i18n v8.0.0 or higher.`)
       nuxtI18nConfig = (await getNuxtModuleOptions('@nuxtjs/i18n') || {}) as NuxtI18nOptions
-      const excludedLocales = getExcludedLocalesFromI18nConfig(nuxtI18nConfig)
-      normalisedLocales = mergeOnKey((nuxtI18nConfig.locales || []).map((locale: any) => typeof locale === 'string' ? { code: locale } : locale), 'code').filter((locale: NormalisedLocale) => !excludedLocales.includes(locale.code))
+      normalisedLocales = mergeOnKey((nuxtI18nConfig.locales || []).map((locale: any) => typeof locale === 'string' ? { code: locale } : locale), 'code')
+      const onlyLocales = getOnlyLocalesFromI18nConfig(nuxtI18nConfig)
+      if (onlyLocales.length) {
+        normalisedLocales = normalisedLocales.filter((locale: NormalisedLocale) => onlyLocales.includes(locale.code))
+      }
       usingI18nPages = !!Object.keys(nuxtI18nConfig.pages || {}).length
       if (usingI18nPages && !hasDisabledAutoI18n) {
         const i18nPagesSources: SitemapSourceBase = {

--- a/src/util/i18n.ts
+++ b/src/util/i18n.ts
@@ -27,11 +27,11 @@ export function splitPathForI18nLocales(path: FilterInput, autoI18n: AutoI18nCon
   ]
 }
 
-export function getExcludedLocalesFromI18nConfig(nuxtI18nConfig: NuxtI18nOptions) {
+export function getOnlyLocalesFromI18nConfig(nuxtI18nConfig: NuxtI18nOptions) {
   const onlyLocales = nuxtI18nConfig?.bundle?.onlyLocales
   if (!onlyLocales) return []
-  const excludedLocales = typeof onlyLocales === 'string' ? [onlyLocales] : onlyLocales
-  return excludedLocales
+  const includedLocales = typeof onlyLocales === 'string' ? [onlyLocales] : onlyLocales
+  return includedLocales
 }
 
 export function generatePathForI18nPages(ctx: StrategyProps): string {

--- a/test/integration/i18n/pages.only-locales.test.ts
+++ b/test/integration/i18n/pages.only-locales.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/i18n'),
+  server: true,
+  nuxtConfig: {
+    i18n: {
+      locales: [
+        {
+          code: 'en',
+          iso: 'en-US',
+        },
+        {
+          code: 'es',
+          iso: 'es-ES',
+        },
+        {
+          code: 'fr',
+          iso: 'fr-FR',
+        },
+      ],
+      bundle: {
+        onlyLocales: ['en', 'fr'],
+      },
+      pages: {
+        'about': {
+          en: '/about',
+          fr: '/a-propos',
+        },
+        'services/index': {
+          en: '/services',
+          fr: '/offres',
+        },
+        'services/development/index': {
+          en: '/services/development',
+          fr: '/offres/developement',
+        },
+        'services/development/app/index': {
+          en: '/services/development/app',
+          fr: '/offres/developement/app',
+        },
+        'services/development/website/index': {
+          en: '/services/development/website',
+          fr: '/offres/developement/site-web',
+        },
+        'services/coaching/index': {
+          en: '/services/coaching',
+          fr: '/offres/formation',
+        },
+        'random': {
+          en: '/random',
+          fr: false,
+        },
+      },
+    },
+  },
+})
+describe('i18n pages only locale', () => {
+  it('basic', async () => {
+    const index = await $fetch('/sitemap_index.xml')
+    expect(index).toMatchInlineSnapshot(`
+      "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
+      <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <sitemap>
+              <loc>https://nuxtseo.com/__sitemap__/en-US.xml</loc>
+          </sitemap>
+          <sitemap>
+              <loc>https://nuxtseo.com/__sitemap__/fr-FR.xml</loc>
+          </sitemap>
+      </sitemapindex>"
+    `)
+    const fr = await $fetch('/__sitemap__/fr-FR.xml')
+    expect(fr).toMatchInlineSnapshot(`
+      "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
+      <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url>
+              <loc>https://nuxtseo.com/fr/a-propos</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/about" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/a-propos" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/about" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/__sitemap/url</loc>
+              <changefreq>weekly</changefreq>
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/__sitemap/url" />
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/__sitemap/url" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/__sitemap/url" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres/developement</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/development" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/developement" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/development" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres/formation</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/coaching" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/formation" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/coaching" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres/developement/app</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/development/app" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/developement/app" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/development/app" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/fr/offres/developement/site-web</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/services/development/website" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/offres/developement/site-web" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/services/development/website" />
+          </url>
+      </urlset>"
+    `)
+  }, 60000)
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Former PR reversed the logic of only locales. It's not excluding, it's including!
Added one test to document the behavior. 
Apologies for the former blunder. 
