### PR TITLE
fix(i18n): broken dedupe of loc and alternatives

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -69,8 +69,6 @@ export function setupPrerenderHandler(_options: { runtimeConfig: ModuleRuntimeCo
       if (!route.fileName?.endsWith('.html') || !html || ['/200.html', '/404.html'].includes(route.route))
         return
 
-      console.log('generating route', route.route, route._sitemap)
-
       // maybe the user already provided a _sitemap on the route
       route._sitemap = defu(route._sitemap, {
         loc: route.route,
@@ -94,8 +92,6 @@ export function setupPrerenderHandler(_options: { runtimeConfig: ModuleRuntimeCo
         lastmod: true,
         alternatives: true,
       }), route._sitemap) as SitemapUrl
-
-      console.log('final', route._sitemap)
     })
     nitro.hooks.hook('prerender:done', async () => {
       // force templates to be rebuilt

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -34,7 +34,7 @@ declare module 'nitropack' {
 }
 
 export function includesSitemapRoot(sitemapName: string, routes: string[]) {
-  return routes.includes(`/sitemap.xml`) || routes.includes(`/${sitemapName}`) || routes.includes('/sitemap_index.xml')
+  return routes.includes(`/__sitemap__/`) || routes.includes(`/sitemap.xml`) || routes.includes(`/${sitemapName}`) || routes.includes('/sitemap_index.xml')
 }
 
 export function isNuxtGenerate(nuxt: Nuxt = useNuxt()) {
@@ -66,8 +66,10 @@ export function setupPrerenderHandler(_options: { runtimeConfig: ModuleRuntimeCo
     nitro.hooks.hook('prerender:generate', async (route) => {
       const html = route.contents
       // extract alternatives from the html
-      if (!route.fileName?.endsWith('.html') || !html)
+      if (!route.fileName?.endsWith('.html') || !html || ['/200.html', '/404.html'].includes(route.route))
         return
+
+      console.log('generating route', route.route, route._sitemap)
 
       // maybe the user already provided a _sitemap on the route
       route._sitemap = defu(route._sitemap, {
@@ -92,6 +94,8 @@ export function setupPrerenderHandler(_options: { runtimeConfig: ModuleRuntimeCo
         lastmod: true,
         alternatives: true,
       }), route._sitemap) as SitemapUrl
+
+      console.log('final', route._sitemap)
     })
     nitro.hooks.hook('prerender:done', async () => {
       // force templates to be rebuilt

--- a/src/runtime/nitro/sitemap/builder/sitemap.ts
+++ b/src/runtime/nitro/sitemap/builder/sitemap.ts
@@ -58,6 +58,7 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, sources: Sitem
         return false
       e._locale = locale
       e._index = i
+      e._key = `${e._sitemap || ''}${e._path?.pathname || '/'}${e._path.search}`
       withoutPrefixPaths[pathWithoutPrefix] = withoutPrefixPaths[pathWithoutPrefix] || []
       // need to make sure the locale doesn't already exist
       if (!withoutPrefixPaths[pathWithoutPrefix].some(e => e._locale.code === locale.code))
@@ -122,7 +123,7 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, sources: Sitem
               _sitemap,
               ...e,
               _index: undefined,
-              _key: `${_sitemap || ''}${loc}`,
+              _key: `${_sitemap || ''}${loc || '/'}${e._path.search}`,
               _locale: l,
               loc,
               alternatives: [{ code: 'x-default', _hreflang: 'x-default' }, ...autoI18n.locales].map((locale) => {
@@ -163,6 +164,7 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, sources: Sitem
       }
       if (isI18nMapped) {
         e._sitemap = e._sitemap || e._locale._sitemap
+        e._key = `${e._sitemap || ''}${e.loc || '/'}${e._path.search}`
       }
       if (e._index)
         _urls[e._index] = e

--- a/src/runtime/nitro/sitemap/nitro.ts
+++ b/src/runtime/nitro/sitemap/nitro.ts
@@ -83,7 +83,9 @@ export async function createSitemap(event: H3Event, definition: SitemapDefinitio
 
   const maybeSort = (urls: ResolvedSitemapUrl[]) => runtimeConfig.sortEntries ? sortSitemapUrls(urls) : urls
   // final urls
-  const urls = maybeSort(mergeOnKey(resolvedCtx.urls.map(e => normaliseEntry(e, definition.defaults, resolvers)), '_key'))
+  const normalizedPreDedupe = resolvedCtx.urls.map(e => normaliseEntry(e, definition.defaults, resolvers))
+  console.log(normalizedPreDedupe)
+  const urls = maybeSort(mergeOnKey(normalizedPreDedupe, '_key').map(e => normaliseEntry(e, definition.defaults, resolvers)))
   const sitemap = urlsToXml(urls, resolvers, runtimeConfig)
 
   const ctx = { sitemap, sitemapName }

--- a/test/unit/i18n.test.ts
+++ b/test/unit/i18n.test.ts
@@ -229,7 +229,7 @@ describe('i18n', () => {
         {
           "_abs": false,
           "_index": 0,
-          "_key": "/en/dynamic/foo",
+          "_key": "en-US/en/dynamic/foo",
           "_locale": {
             "_hreflang": "en-US",
             "_sitemap": "en-US",
@@ -263,7 +263,7 @@ describe('i18n', () => {
         {
           "_abs": false,
           "_index": 1,
-          "_key": "/fr/dynamic/foo",
+          "_key": "fr-FR/fr/dynamic/foo",
           "_locale": {
             "_hreflang": "fr-FR",
             "_sitemap": "fr-FR",
@@ -331,7 +331,7 @@ describe('i18n', () => {
         {
           "_abs": false,
           "_index": 3,
-          "_key": "english-url",
+          "_key": "en-USenglish-url",
           "_locale": {
             "_hreflang": "en-US",
             "_sitemap": "en-US",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

https://github.com/nuxt-modules/sitemap/issues/333

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

URLs are not being deduped properly when we have i18n enabled.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
