### PR TITLE
fix: doubly encoding of URLs

### DIFF
--- a/src/runtime/server/sitemap/urlset/normalise.ts
+++ b/src/runtime/server/sitemap/urlset/normalise.ts
@@ -65,7 +65,7 @@ export function preNormalizeEntry(_e: SitemapUrl | string, resolvers?: NitroUrlR
       e.loc = e._relativeLoc
     }
   }
-  else {
+  else if (!isEncoded(e.loc)) {
     e.loc = encodeURI(e.loc)
   }
   if (e.loc === '')
@@ -73,6 +73,16 @@ export function preNormalizeEntry(_e: SitemapUrl | string, resolvers?: NitroUrlR
   e.loc = resolve(e.loc, resolvers)
   e._key = `${e._sitemap || ''}${withoutTrailingSlash(e.loc)}`
   return e as ResolvedSitemapUrl
+}
+
+export function isEncoded(url: string) {
+  // checks, if an url is already decoded
+  try {
+    return url !== decodeURIComponent(url)
+  }
+  catch {
+    return false
+  }
 }
 
 export function normaliseEntry(_e: ResolvedSitemapUrl, defaults: Omit<SitemapUrl, 'loc'>, resolvers?: NitroUrlResolvers): ResolvedSitemapUrl {

--- a/test/integration/single/urlEncoded.test.ts
+++ b/test/integration/single/urlEncoded.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/basic'),
+  nuxtConfig: {
+    sitemap: {
+      urls: [
+        '/Bücher',
+        '/Bibliothèque',
+      ],
+    },
+  },
+})
+describe('query routes', () => {
+  it('should be url encoded', async () => {
+    const sitemap = await $fetch('/sitemap.xml')
+
+    expect(sitemap).toContain('<loc>https://nuxtseo.com/B%C3%BCcher</loc>')
+    expect(sitemap).toContain('<loc>https://nuxtseo.com/Biblioth%C3%A8que</loc>')
+    expect(sitemap).not.toContain('https://nuxtseo.com/Bücher')
+    expect(sitemap).not.toContain('https://nuxtseo.com/Bibliothèque')
+  }, 60000)
+})


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I'm building a blog nuxt app and using the sitemap module. While reading the sitemap, I recognized that the URLs containing umlauts like ä, ö, ü, ß and also á, à etc. are invalid. They get doubly encoded. For example: `/Bücher` should be encoded to `/B%C3%BCcher`, but now it is `/B%25C3%25BCcher`. The latter value is generated, when the first value (`/Bücher`) get URL encoded twice, so `decodeURI(decodeURI('B%25C3%25BCcher'))` will lead to `/Bücher` again. 

This PR is addressing this issue, also providing a test, to show that it really only gets encoded once. For this, a little helper function was introduced (`isEncoded`) to check if a string is already encoded or not.

I didn't add a test showing the issue, only one for the solution..

The failing eslint checks seems unrelated to the changes..