### PR TITLE
feat: external XML sitemaps as sources

### DIFF
--- a/docs/content/2.guides/0.data-sources.md
+++ b/docs/content/2.guides/0.data-sources.md
@@ -72,7 +72,8 @@ export default defineNuxtConfig({
 
 If you need your sitemap data to always be up-to-date at runtime, you will need to provide your own sources explicitly.
 
-A source is a URL that will be fetched and is expected to return an array of Sitemap URL entries.
+A source is a URL that will be fetched and is expected to return either JSON with an array of Sitemap URL entries or
+a XML sitemap.
 
 ::code-group
 

--- a/docs/content/2.guides/0.multi-sitemaps.md
+++ b/docs/content/2.guides/0.multi-sitemaps.md
@@ -166,7 +166,7 @@ export default defineSitemapEventHandler(() => {
 If you need to fetch the URLs from an endpoint for a sitemap, then you will need to use either the `urls` or `sources` option.
 
 - `urls` - Array of static URLs to include in the sitemap. You should avoid using this option if you have a lot of URLs
-- `sources` - Custom endpoint to fetch [dynamic URLs](/docs/sitemap/guides/dynamic-urls) from.
+- `sources` - Custom endpoint to fetch [dynamic URLs](/docs/sitemap/guides/dynamic-urls) from as JSON or XML.
 
 ```ts
 export default defineNuxtConfig({

--- a/docs/content/2.guides/2.dynamic-urls.md
+++ b/docs/content/2.guides/2.dynamic-urls.md
@@ -8,7 +8,22 @@ description: Use runtime API endpoints to generate dynamic URLs for your sitemap
 In some instances, like using a CMS, you may need to implement an endpoint to make
 all of your site URLs visible to the module.
 
-To do this, you can provide [user sources](/docs/sitemap/getting-started/data-sources) to the module.
+To do this, you can provide [user sources](/docs/sitemap/getting-started/data-sources) to the module. These can either be 
+a JSON response or an XML sitemap.
+
+## XML Sitemap
+
+If you're providing an XML sitemap, you can use the `sources` option to provide the URL to the sitemap.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  sitemap: {
+    sources: [
+      'https://example.com/sitemap.xml',
+    ]
+  }
+})
+```
 
 ## Dynamic URLs from an external API
 

--- a/src/runtime/server/sitemap/urlset/sources.ts
+++ b/src/runtime/server/sitemap/urlset/sources.ts
@@ -9,7 +9,7 @@ import type {
   SitemapSourceResolved,
   SitemapUrlInput,
 } from '../../../types'
-import { extractSitemapXML } from '#sitemap/server/sitemap/utils/extractSitemapXML'
+import { extractSitemapXML } from '../utils/extractSitemapXML'
 
 export async function fetchDataSource(input: SitemapSourceBase | SitemapSourceResolved, event?: H3Event): Promise<SitemapSourceResolved> {
   const context = typeof input.context === 'string' ? { name: input.context } : input.context || { name: 'fetch' }
@@ -29,10 +29,10 @@ export async function fetchDataSource(input: SitemapSourceBase | SitemapSourceRe
   try {
     const res = await fetchContainer.$fetch(url, {
       ...options,
-      responseType: isXmlRequest ? 'json' : 'text',
+      responseType: isXmlRequest ? 'text' : 'json',
       signal: timeoutController.signal,
       headers: defu(options?.headers, {
-        Accept: 'application/json',
+        Accept: isXmlRequest ? 'text/xml' : 'application/json',
       }, event ? { Host: getRequestHost(event, { xForwardedHost: true }) } : {}),
       // @ts-expect-error untyped
       onResponse({ response }) {

--- a/src/runtime/server/sitemap/utils/extractSitemapXML.ts
+++ b/src/runtime/server/sitemap/utils/extractSitemapXML.ts
@@ -1,0 +1,101 @@
+import type { SitemapUrlInput } from '../../../types'
+
+export function extractSitemapXML(xml: string): SitemapUrlInput[] {
+  const urls = xml.match(/<url>[\s\S]*?<\/url>/g) || []
+  return urls.map((url) => {
+    const loc = url.match(/<loc>([^<]+)<\/loc>/)?.[1]
+    if (!loc) return null
+
+    const lastmod = url.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1]
+    const changefreq = url.match(/<changefreq>([^<]+)<\/changefreq>/)?.[1]
+    const priority = url.match(/<priority>([^<]+)<\/priority>/) ? Number.parseFloat(url.match(/<priority>([^<]+)<\/priority>/)[1]) : undefined
+
+    const images = (url.match(/<image:image>[\s\S]*?<\/image:image>/g) || []).map((image) => {
+      const imageLoc = image.match(/<image:loc>([^<]+)<\/image:loc>/)?.[1]
+      return imageLoc ? { loc: imageLoc } : null
+    }).filter(Boolean)
+
+    const videos = (url.match(/<video:video>[\s\S]*?<\/video:video>/g) || []).map((video) => {
+      const videoObj: any = {}
+      const title = video.match(/<video:title>([^<]+)<\/video:title>/)?.[1]
+      const thumbnail_loc = video.match(/<video:thumbnail_loc>([^<]+)<\/video:thumbnail_loc>/)?.[1]
+      const description = video.match(/<video:description>([^<]+)<\/video:description>/)?.[1]
+      const content_loc = video.match(/<video:content_loc>([^<]+)<\/video:content_loc>/)?.[1]
+      if (!title || !thumbnail_loc || !description || !content_loc) return null
+
+      videoObj.title = title
+      videoObj.thumbnail_loc = thumbnail_loc
+      videoObj.description = description
+      videoObj.content_loc = content_loc
+
+      const player_loc = video.match(/<video:player_loc>([^<]+)<\/video:player_loc>/)?.[1]
+      if (player_loc) videoObj.player_loc = player_loc
+
+      const duration = video.match(/<video:duration>([^<]+)<\/video:duration>/) ? Number.parseInt(video.match(/<video:duration>([^<]+)<\/video:duration>/)[1], 10) : undefined
+      if (duration) videoObj.duration = duration
+
+      const expiration_date = video.match(/<video:expiration_date>([^<]+)<\/video:expiration_date>/)?.[1]
+      if (expiration_date) videoObj.expiration_date = expiration_date
+
+      const rating = video.match(/<video:rating>([^<]+)<\/video:rating>/) ? Number.parseFloat(video.match(/<video:rating>([^<]+)<\/video:rating>/)[1]) : undefined
+      if (rating) videoObj.rating = rating
+
+      const view_count = video.match(/<video:view_count>([^<]+)<\/video:view_count>/) ? Number.parseInt(video.match(/<video:view_count>([^<]+)<\/video:view_count>/)[1], 10) : undefined
+      if (view_count) videoObj.view_count = view_count
+
+      const publication_date = video.match(/<video:publication_date>([^<]+)<\/video:publication_date>/)?.[1]
+      if (publication_date) videoObj.publication_date = publication_date
+
+      const family_friendly = video.match(/<video:family_friendly>([^<]+)<\/video:family_friendly>/)?.[1]
+      if (family_friendly) videoObj.family_friendly = family_friendly
+
+      const restriction = video.match(/<video:restriction relationship="([^"]+)">([^<]+)<\/video:restriction>/)
+      if (restriction) videoObj.restriction = { relationship: restriction[1], restriction: restriction[2] }
+
+      const platform = video.match(/<video:platform relationship="([^"]+)">([^<]+)<\/video:platform>/)
+      if (platform) videoObj.platform = { relationship: platform[1], platform: platform[2] }
+
+      const price = (video.match(/<video:price [^>]+>([^<]+)<\/video:price>/g) || []).map((price) => {
+        const priceValue = price.match(/<video:price [^>]+>([^<]+)<\/video:price>/)?.[1]
+        const currency = price.match(/currency="([^"]+)"/)?.[1]
+        const type = price.match(/type="([^"]+)"/)?.[1]
+        return priceValue ? { price: priceValue, currency, type } : null
+      }).filter(Boolean)
+      if (price.length) videoObj.price = price
+
+      const requires_subscription = video.match(/<video:requires_subscription>([^<]+)<\/video:requires_subscription>/)?.[1]
+      if (requires_subscription) videoObj.requires_subscription = requires_subscription
+
+      const uploader = video.match(/<video:uploader info="([^"]+)">([^<]+)<\/video:uploader>/)
+      if (uploader) videoObj.uploader = { uploader: uploader[2], info: uploader[1] }
+
+      const live = video.match(/<video:live>([^<]+)<\/video:live>/)?.[1]
+      if (live) videoObj.live = live
+
+      const tag = (video.match(/<video:tag>([^<]+)<\/video:tag>/g) || []).map(tag => tag.match(/<video:tag>([^<]+)<\/video:tag>/)?.[1]).filter(Boolean)
+      if (tag.length) videoObj.tag = tag
+
+      return videoObj
+    }).filter(Boolean)
+
+    const alternatives = (url.match(/<xhtml:link[\s\S]*?\/>/g) || []).map((link) => {
+      const hreflang = link.match(/hreflang="([^"]+)"/)?.[1]
+      const href = link.match(/href="([^"]+)"/)?.[1]
+      return hreflang && href ? { hreflang, href } : null
+    }).filter(Boolean)
+
+    const news = url.match(/<news:news>[\s\S]*?<\/news:news>/)
+      ? {
+          title: url.match(/<news:title>([^<]+)<\/news:title>/)?.[1],
+          publication_date: url.match(/<news:publication_date>([^<]+)<\/news:publication_date>/)?.[1],
+          publication: {
+            name: url.match(/<news:name>([^<]+)<\/news:name>/)?.[1],
+            language: url.match(/<news:language>([^<]+)<\/news:language>/)?.[1],
+          },
+        }
+      : undefined
+
+    const urlObj: any = { loc, lastmod, changefreq, priority, images, videos, alternatives, news }
+    return Object.fromEntries(Object.entries(urlObj).filter(([_, v]) => v != null && v.length !== 0))
+  }).filter(Boolean) as any as SitemapUrlInput[]
+}

--- a/test/unit/extractSitemapXML.ts
+++ b/test/unit/extractSitemapXML.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import { extractSitemapXML } from '../../src/runtime/server/sitemap/utils/extractSitemapXML'
+
+describe('extractSitemapXML', () => {
+  it('should extract loc, lastmod, changefreq, priority, images, videos, alternatives, and news from XML', () => {
+    const xml = `
+      <urlset>
+        <url>
+          <loc>http://example.com/</loc>
+          <lastmod>2023-01-01</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.8</priority>
+          <image:image>
+            <image:loc>http://example.com/image1.jpg</image:loc>
+          </image:image>
+          <video:video>
+            <video:title>Example Video</video:title>
+            <video:thumbnail_loc>http://example.com/thumbnail.jpg</video:thumbnail_loc>
+            <video:description>Example Description</video:description>
+            <video:content_loc>http://example.com/video1.mp4</video:content_loc>
+            <video:duration>600</video:duration>
+          </video:video>
+          <xhtml:link rel="alternate" hreflang="en" href="http://example.com/en"/>
+          <news:news>
+            <news:title>Example News</news:title>
+            <news:publication_date>2023-01-01</news:publication_date>
+            <news:publication>
+              <news:name>Example Publication</news:name>
+              <news:language>en</news:language>
+            </news:publication>
+          </news:news>
+        </url>
+      </urlset>
+    `
+    const result = extractSitemapXML(xml)
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "alternatives": [
+            {
+              "href": "http://example.com/en",
+              "hreflang": "en",
+            },
+          ],
+          "changefreq": "daily",
+          "images": [
+            {
+              "loc": "http://example.com/image1.jpg",
+            },
+          ],
+          "lastmod": "2023-01-01",
+          "loc": "http://example.com/",
+          "news": {
+            "publication": {
+              "language": "en",
+              "name": "Example Publication",
+            },
+            "publication_date": "2023-01-01",
+            "title": "Example News",
+          },
+          "priority": 0.8,
+          "videos": [
+            {
+              "content_loc": "http://example.com/video1.mp4",
+              "description": "Example Description",
+              "duration": 600,
+              "thumbnail_loc": "http://example.com/thumbnail.jpg",
+              "title": "Example Video",
+            },
+          ],
+        },
+      ]
+    `)
+  })
+
+  it('should handle missing optional fields', () => {
+    const xml = `
+      <urlset>
+        <url>
+          <loc>http://example.com/</loc>
+          <lastmod>2023-01-01</lastmod>
+          <changefreq>daily</changefreq>
+        </url>
+      </urlset>
+    `
+    const result = extractSitemapXML(xml)
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "changefreq": "daily",
+          "lastmod": "2023-01-01",
+          "loc": "http://example.com/",
+        },
+      ]
+    `)
+  })
+
+  it('should handle multiple images and videos', () => {
+    const xml = `
+      <urlset>
+        <url>
+          <loc>http://example.com/</loc>
+          <image:image>
+            <image:loc>http://example.com/image1.jpg</image:loc>
+          </image:image>
+          <image:image>
+            <image:loc>http://example.com/image2.jpg</image:loc>
+          </image:image>
+          <video:video>
+            <video:title>Example Video 1</video:title>
+            <video:thumbnail_loc>http://example.com/thumbnail1.jpg</video:thumbnail_loc>
+            <video:description>Example Description 1</video:description>
+            <video:content_loc>http://example.com/video1.mp4</video:content_loc>
+          </video:video>
+          <video:video>
+            <video:title>Example Video 2</video:title>
+            <video:thumbnail_loc>http://example.com/thumbnail2.jpg</video:thumbnail_loc>
+            <video:description>Example Description 2</video:description>
+            <video:content_loc>http://example.com/video2.mp4</video:content_loc>
+          </video:video>
+        </url>
+      </urlset>
+    `
+    const result = extractSitemapXML(xml)
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "images": [
+            {
+              "loc": "http://example.com/image1.jpg",
+            },
+            {
+              "loc": "http://example.com/image2.jpg",
+            },
+          ],
+          "loc": "http://example.com/",
+          "videos": [
+            {
+              "content_loc": "http://example.com/video1.mp4",
+              "description": "Example Description 1",
+              "thumbnail_loc": "http://example.com/thumbnail1.jpg",
+              "title": "Example Video 1",
+            },
+            {
+              "content_loc": "http://example.com/video2.mp4",
+              "description": "Example Description 2",
+              "thumbnail_loc": "http://example.com/thumbnail2.jpg",
+              "title": "Example Video 2",
+            },
+          ],
+        },
+      ]
+    `)
+  })
+
+  it('should handle missing loc, lastmod, and changefreq', () => {
+    const xml = `
+      <urlset>
+        <url>
+          <image:image>
+            <image:loc>http://example.com/image1.jpg</image:loc>
+          </image:image>
+        </url>
+      </urlset>
+    `
+    const result = extractSitemapXML(xml)
+    expect(result).toMatchInlineSnapshot(`[]`)
+  })
+
+  it('should return an empty array if no URLs are found', () => {
+    const xml = '<urlset></urlset>'
+    const result = extractSitemapXML(xml)
+    expect(result).toMatchInlineSnapshot(`[]`)
+  })
+
+  it('should handle malformed XML', () => {
+    const xml = `
+      <urlset>
+        <url>
+          <ldoc>http://example.com/
+          <lastmod>2023-01-01</lastmod>
+          <changefreq>daily</changefreq>
+        </url>
+      </urlset>
+    `
+    const result = extractSitemapXML(xml)
+    expect(result).toMatchInlineSnapshot(`[]`)
+  })
+
+  it('should handle XML with unexpected tags', () => {
+    const xml = `
+      <urlset>
+        <url>
+          <loc>http://example.com/</loc>
+          <unexpectedTag>unexpectedValue</unexpectedTag>
+        </url>
+      </urlset>
+    `
+    const result = extractSitemapXML(xml)
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "loc": "http://example.com/",
+        },
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/harlan-zw/nuxt-seo/issues/359

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Load XML sitemaps as sources and it _just works_.

```ts
export default defineNuxtConfig({
  sitemap: {
    sources: [
      'https://nuxtseo.com/sitemap.xml',
    ],
  }
})
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
