### PR TITLE
docs: correct link to sitemap guide

### DIFF
--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -19,7 +19,7 @@ and easy to miss best practices.
 
 Nuxt Sitemap automatically generates the sitemap for you based on your site's content, including lastmod, image discovery and more.
 
-Ready to get started? Check out the [installation guide](/docs/robots/getting-started/installation) or learn more on the [Controlling Web Crawlers](https://nuxtseo.com/learn/controlling-crawlers) guide.
+Ready to get started? Check out the [installation guide](/docs/sitemap/getting-started/installation) or learn more on the [Controlling Web Crawlers](https://nuxtseo.com/learn/controlling-crawlers) guide.
 
 ## Features
 


### PR DESCRIPTION
### ❓ Type of change
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The 'installation guide'-link pointed to the 'robots' installation guide, this corrects it to point to the sitemap guide.
