### PR TITLE
doc: rename references to xsl instead of xls

### DIFF
--- a/docs/content/2.guides/6.customising-ui.md
+++ b/docs/content/2.guides/6.customising-ui.md
@@ -3,12 +3,12 @@ title: Customising the UI
 description: Change the look and feel of your sitemap.
 ---
 
-## Disabling the XLS
+## Disabling the XSL
 
-What you're looking at when you view the sitemap.xml is a XLS file, think of it just like you would a CSS file for HTML.
+What you're looking at when you view the sitemap.xml is a XSL file, think of it just like you would a CSS file for HTML.
 
 To view the real sitemap.xml, you can view the source of the page.
-If you prefer, you can disable the XLS by setting `xsl` to `false`.
+If you prefer, you can disable the XSL by setting `xsl` to `false`.
 
 ```ts
 export default defineNuxtConfig({
@@ -38,7 +38,7 @@ export default defineNuxtConfig({
 })
 ```
 
-The `select` you provide is an XLS expression that will be evaluated against the sitemap entry.
+The `select` you provide is an XSL expression that will be evaluated against the sitemap entry.
 It's recommended to prefix the value with `sitemap:` if in doubt.
 
 ### Example: Adding priority and changefreq


### PR DESCRIPTION
XSL is the stylesheet for XML, XLS is a spreadsheet file format for Microsoft Excel

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replace references to XLS, a spreadsheet file format, with XSL, the stylesheet for XML to reduce confusion.
