### PR TITLE
feat: runtime sources

### DIFF
--- a/docs/content/2.guides/0.data-sources.md
+++ b/docs/content/2.guides/0.data-sources.md
@@ -116,3 +116,37 @@ export default defineNuxtConfig({
 You can provide any number of sources, however, you should consider your own caching strategy.
 
 You can learn more about data sources on the [Dynamic URLs](/docs/sitemap/guides/dynamic-urls) guide.
+
+### Dynamic Sources and Headers
+
+You can dynamically add sources or modify existing sources at runtime using the `sitemap:sources` Nitro hook:
+
+```ts [server/plugins/sitemap.ts]
+import { defineNitroPlugin } from 'nitropack/runtime'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('sitemap:sources', async (ctx) => {
+    // Add a new source dynamically
+    ctx.sources.push('/api/runtime-urls')
+    
+    // Modify existing sources to add headers
+    ctx.sources = ctx.sources.map(source => {
+      if (typeof source === 'object' && source.fetch) {
+        const [url, options = {}] = Array.isArray(source.fetch) ? source.fetch : [source.fetch, {}]
+        
+        // Forward authorization header from original request
+        const authHeader = ctx.event.node.req.headers.authorization
+        if (authHeader) {
+          options.headers = options.headers || {}
+          options.headers['Authorization'] = authHeader
+        }
+        
+        source.fetch = [url, options]
+      }
+      return source
+    })
+  })
+})
+```
+
+Learn more about [Nitro Hooks](/docs/sitemap/nitro-api/nitro-hooks#sitemap-sources).

--- a/docs/content/2.guides/0.data-sources.md
+++ b/docs/content/2.guides/0.data-sources.md
@@ -124,6 +124,7 @@ For advanced use cases, you can dynamically add or modify sources at runtime usi
 
 ```ts [server/plugins/sitemap.ts]
 import { defineNitroPlugin } from 'nitropack/runtime'
+import { getHeader } from 'h3'
 
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('sitemap:sources', async (ctx) => {
@@ -136,7 +137,7 @@ export default defineNitroPlugin((nitroApp) => {
         const [url, options = {}] = Array.isArray(source.fetch) ? source.fetch : [source.fetch, {}]
         
         // Forward authorization header from original request
-        const authHeader = ctx.event.node.req.headers.authorization
+        const authHeader = getHeader(ctx.event, 'authorization')
         if (authHeader) {
           options.headers = options.headers || {}
           options.headers['Authorization'] = authHeader

--- a/docs/content/2.guides/0.data-sources.md
+++ b/docs/content/2.guides/0.data-sources.md
@@ -3,14 +3,15 @@ title: Data Sources
 description: Learn how the Nuxt Sitemap sources work.
 ---
 
-Every URL within your sitemap will belong to a source.
+Every URL within your sitemap will belong to a source. Sources determine where your sitemap URLs come from and how they're managed.
 
-A source will either be a User source or an Application source.
+Sources are categorized into two types:
+- **Application Sources**: Automatically generated from your application
+- **User Sources**: Manually configured by you
 
 ## Application Sources
 
-Application sources are sources generated automatically from your app. These are in place to make using the module more
-convenient but may get in the way.
+Application sources are automatically generated from your Nuxt application. They provide convenience by automatically discovering URLs from your app's structure, but can be disabled if they don't match your needs.
 
 - `nuxt:pages` - Statically analysed pages of your application
 - `nuxt:prerender` - URLs that were prerendered
@@ -18,9 +19,9 @@ convenient but may get in the way.
 - `@nuxtjs/i18n:pages` - When using the `pages` config with Nuxt I18n. See [Nuxt I18n](/docs/sitemap/integrations/i18n) for more details.
 - `@nuxt/content:document-driven` - When using Document Driven mode. See [Nuxt Content](/docs/sitemap/integrations/content) for more details.
 
-### Disabling application sources
+### Disabling Application Sources
 
-You can opt out of application sources individually or all of them by using the `excludeAppSources` config.
+You can disable application sources individually or all at once using the `excludeAppSources` config option.
 
 ::code-group
 
@@ -46,15 +47,13 @@ export default defineNuxtConfig({
 
 ## User Sources
 
-When working with a site that has dynamic routes that isn't using [prerendering discovery](/docs/sitemap/guides/prerendering), you will need to provide your own sources.
+User sources allow you to manually configure where your sitemap URLs come from. These are especially useful for dynamic routes that aren't using [prerendering discovery](/docs/sitemap/guides/prerendering).
 
-For this, you have a few options:
+You have several options for providing user sources:
 
-## 1. Build time: provide a `urls` function
+### 1. Build-time Sources with `urls` Function
 
-If you only need your sitemap data concurrent when you build, then providing a `urls` function is the simplest way to provide your own sources.
-
-This function will only be run when the sitemap is generated.
+For sitemap data that only needs to be updated at build time, the `urls` function is the simplest solution. This function runs once during sitemap generation.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -68,12 +67,11 @@ export default defineNuxtConfig({
 })
 ```
 
-### 2. Runtime: provide a `sources` array
+### 2. Runtime Sources with `sources` Array
 
-If you need your sitemap data to always be up-to-date at runtime, you will need to provide your own sources explicitly.
-
-A source is a URL that will be fetched and is expected to return either JSON with an array of Sitemap URL entries or
-a XML sitemap.
+For sitemap data that must always be up-to-date at runtime, use the `sources` array. Each source is a URL that gets fetched and should return either:
+- JSON array of sitemap URL entries
+- XML sitemap document
 
 ::code-group
 
@@ -113,13 +111,16 @@ export default defineNuxtConfig({
 
 ::
 
-You can provide any number of sources, however, you should consider your own caching strategy.
+You can provide multiple sources, but consider implementing your own caching strategy for performance.
 
-You can learn more about data sources on the [Dynamic URLs](/docs/sitemap/guides/dynamic-urls) guide.
+Learn more about working with dynamic data in the [Dynamic URLs](/docs/sitemap/guides/dynamic-urls) guide.
 
-### Dynamic Sources and Headers
+### 3. Dynamic Sources Using Nitro Hooks
 
-You can dynamically add sources or modify existing sources at runtime using the `sitemap:sources` Nitro hook:
+For advanced use cases, you can dynamically add or modify sources at runtime using the `sitemap:sources` Nitro hook. This is useful for:
+- Adding sources based on request context
+- Forwarding authentication headers
+- Modifying source configurations on the fly
 
 ```ts [server/plugins/sitemap.ts]
 import { defineNitroPlugin } from 'nitropack/runtime'
@@ -149,4 +150,4 @@ export default defineNitroPlugin((nitroApp) => {
 })
 ```
 
-Learn more about [Nitro Hooks](/docs/sitemap/nitro-api/nitro-hooks#sitemap-sources).
+Learn more about the sitemap hooks in the [Nitro Hooks documentation](/docs/sitemap/nitro-api/nitro-hooks#sitemap-sources).

--- a/src/module.ts
+++ b/src/module.ts
@@ -295,6 +295,7 @@ declare module 'nitropack' {
     'sitemap:input': (ctx: import('${typesPath}').SitemapInputCtx) => void | Promise<void>
     'sitemap:resolved': (ctx: import('${typesPath}').SitemapRenderCtx) => void | Promise<void>
     'sitemap:output': (ctx: import('${typesPath}').SitemapOutputHookCtx) => void | Promise<void>
+    'sitemap:sources': (ctx: import('${typesPath}').SitemapSourcesHookCtx) => void | Promise<void>
   }
 }
 declare module 'vue-router' {

--- a/src/runtime/server/routes/__sitemap__/debug.ts
+++ b/src/runtime/server/routes/__sitemap__/debug.ts
@@ -21,13 +21,13 @@ export default defineEventHandler(async (e) => {
     // resolve the sources
     sitemaps[s] = {
       ..._sitemaps[s],
-      sources: await resolveSitemapSources(await childSitemapSources(_sitemaps[s])),
+      sources: await resolveSitemapSources(await childSitemapSources(_sitemaps[s]), e),
     }
   }
   return {
     nitroOrigin,
     sitemaps,
     runtimeConfig,
-    globalSources: await resolveSitemapSources(globalSources),
+    globalSources: await resolveSitemapSources(globalSources, e),
   }
 })

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -326,6 +326,11 @@ export interface SitemapOutputHookCtx extends NitroBaseHook {
   sitemap: string
 }
 
+export interface SitemapSourcesHookCtx extends NitroBaseHook {
+  sitemapName: string
+  sources: (SitemapSourceBase | SitemapSourceResolved)[]
+}
+
 export type Changefreq =
   | 'always'
   | 'hourly'

--- a/test/fixtures/sources-hook/nuxt.config.ts
+++ b/test/fixtures/sources-hook/nuxt.config.ts
@@ -1,0 +1,19 @@
+import { defineNuxtConfig } from 'nuxt/config'
+import NuxtSitemap from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    NuxtSitemap,
+  ],
+  site: {
+    url: 'https://example.com',
+  },
+  nitro: {
+    plugins: ['~/server/plugins/sources-hook.ts'],
+  },
+  sitemap: {
+    sources: [
+      '/api/initial-source',
+    ],
+  },
+})

--- a/test/fixtures/sources-hook/pages/index.vue
+++ b/test/fixtures/sources-hook/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Test fixture for sources hook</div>
+</template>

--- a/test/fixtures/sources-hook/server/api/dynamic-source.ts
+++ b/test/fixtures/sources-hook/server/api/dynamic-source.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => {
+  return [
+    { loc: '/dynamic-source-url' },
+  ]
+})

--- a/test/fixtures/sources-hook/server/api/initial-source.ts
+++ b/test/fixtures/sources-hook/server/api/initial-source.ts
@@ -1,0 +1,16 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler((event) => {
+  const headers = event.node.req.headers
+
+  // Return different URLs based on whether headers were modified by hook
+  if (headers['x-hook-modified'] === 'true') {
+    return [
+      { loc: '/hook-modified' },
+    ]
+  }
+
+  return [
+    { loc: '/initial-source-default' },
+  ]
+})

--- a/test/fixtures/sources-hook/server/plugins/sources-hook.ts
+++ b/test/fixtures/sources-hook/server/plugins/sources-hook.ts
@@ -1,0 +1,28 @@
+import { defineNitroPlugin } from 'nitropack/runtime'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('sitemap:sources', async (ctx) => {
+    // Add a new source dynamically
+    ctx.sources.push({ sourceType: 'user', fetch: '/api/dynamic-source' })
+
+    // Add a source to be filtered
+    ctx.sources.push({ sourceType: 'user', fetch: '/api/skip-this' })
+
+    // Modify existing sources to add headers
+    ctx.sources = ctx.sources.map((source) => {
+      if (typeof source === 'object' && source.fetch === '/api/initial-source') {
+        // Modify fetch to add headers
+        source.fetch = ['/api/initial-source', { headers: { 'X-Hook-Modified': 'true' } }]
+      }
+      return source
+    })
+
+    // Filter out sources we don't want
+    ctx.sources = ctx.sources.filter((source) => {
+      if (typeof source === 'object' && source.fetch) {
+        return !source.fetch.includes('skip-this')
+      }
+      return true
+    })
+  })
+})

--- a/test/integration/hooks/sources-hook-simple.test.ts
+++ b/test/integration/hooks/sources-hook-simple.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { createResolver } from '@nuxt/kit'
+import { setup, $fetch } from '@nuxt/test-utils'
+
+const { resolve } = createResolver(import.meta.url)
+
+describe('sitemap:sources hook', async () => {
+  await setup({
+    rootDir: resolve('../../fixtures/sources-hook'),
+    server: true,
+  })
+
+  it('can add new sources dynamically', async () => {
+    const sitemap = await $fetch('/sitemap.xml')
+
+    // Should have URLs from the dynamically added source
+    expect(sitemap).toContain('<loc>https://example.com/dynamic-source-url</loc>')
+  })
+
+  it('can modify existing sources', async () => {
+    const sitemap = await $fetch('/sitemap.xml')
+
+    // Should have URLs showing the headers were modified
+    expect(sitemap).toContain('<loc>https://example.com/hook-modified</loc>')
+  })
+
+  it('can filter out sources', async () => {
+    const sitemap = await $fetch('/sitemap.xml')
+
+    // The skipped source should not appear in the sitemap
+    expect(sitemap).not.toContain('<loc>https://example.com/should-be-filtered</loc>')
+  })
+})

--- a/test/unit/sourcesHook.test.ts
+++ b/test/unit/sourcesHook.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import type { H3Event } from 'h3'
+import type { SitemapSourcesHookCtx } from '../../src/runtime/types'
+
+describe('sitemap:sources hook', () => {
+  it('hook context is correctly typed', () => {
+    // This is a type test to ensure our hook context is properly structured
+    const mockEvent: Partial<H3Event> = {
+      node: {
+        req: {
+          headers: {
+            authorization: 'Bearer test-token',
+          },
+        } as any,
+      } as any,
+    }
+
+    const ctx: SitemapSourcesHookCtx = {
+      event: mockEvent as H3Event,
+      sitemapName: 'test-sitemap',
+      sources: [
+        '/api/test1',
+        ['/api/test2', { headers: { 'X-Original': 'original' } }],
+      ],
+    }
+
+    // Type checks - ensuring the structure is correct
+    expect(ctx.event).toBeDefined()
+    expect(ctx.sitemapName).toBe('test-sitemap')
+    expect(ctx.sources).toBeDefined()
+    expect(ctx.sources).toHaveLength(2)
+  })
+
+  it('hook can add new sources', () => {
+    const mockEvent: Partial<H3Event> = {
+      node: {
+        req: {
+          headers: {
+            authorization: 'Bearer test-token',
+          },
+        } as any,
+      } as any,
+    }
+
+    const ctx: SitemapSourcesHookCtx = {
+      event: mockEvent as H3Event,
+      sitemapName: 'test-sitemap',
+      sources: ['/api/existing'],
+    }
+
+    // Simulate adding a new source
+    ctx.sources.push('/api/new-source')
+
+    expect(ctx.sources).toHaveLength(2)
+    expect(ctx.sources).toContain('/api/new-source')
+  })
+
+  it('hook can modify source headers', () => {
+    const mockEvent: Partial<H3Event> = {
+      node: {
+        req: {
+          headers: {
+            authorization: 'Bearer test-token',
+          },
+        } as any,
+      } as any,
+    }
+
+    const ctx: SitemapSourcesHookCtx = {
+      event: mockEvent as H3Event,
+      sitemapName: 'test-sitemap',
+      sources: [
+        { fetch: ['/api/test', { headers: { 'X-Original': 'original' } }] } as any,
+      ],
+    }
+
+    // Simulate what a hook would do
+    ctx.sources = ctx.sources.map((source) => {
+      if (typeof source === 'object' && source.fetch) {
+        const [url, options = {}] = Array.isArray(source.fetch) ? source.fetch : [source.fetch, {}]
+
+        options.headers = options.headers || {}
+        options.headers['X-Custom'] = 'custom-value'
+
+        const authHeader = ctx.event.node?.req?.headers?.authorization
+        if (authHeader) {
+          options.headers['Authorization'] = authHeader
+        }
+
+        return { ...source, fetch: [url, options] }
+      }
+      return source
+    })
+
+    // Verify the modifications
+    const modifiedSource = ctx.sources[0] as any
+    const headers = modifiedSource.fetch[1].headers
+    expect(headers['X-Original']).toBe('original')
+    expect(headers['X-Custom']).toBe('custom-value')
+    expect(headers['Authorization']).toBe('Bearer test-token')
+  })
+
+  it('hook can filter sources', () => {
+    const mockEvent: Partial<H3Event> = {
+      node: {
+        req: {
+          headers: {},
+        } as any,
+      } as any,
+    }
+
+    const ctx: SitemapSourcesHookCtx = {
+      event: mockEvent as H3Event,
+      sitemapName: 'test-sitemap',
+      sources: [
+        '/api/keep-this',
+        '/api/skip-this',
+        '/api/also-keep',
+      ],
+    }
+
+    // Simulate filtering sources
+    ctx.sources = ctx.sources.filter((source) => {
+      if (typeof source === 'string') {
+        return !source.includes('skip-this')
+      }
+      return true
+    })
+
+    expect(ctx.sources).toHaveLength(2)
+    expect(ctx.sources).not.toContain('/api/skip-this')
+    expect(ctx.sources).toContain('/api/keep-this')
+    expect(ctx.sources).toContain('/api/also-keep')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

#433

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There are instances where we won't know the sources of our sitemap until runtime (or headers required to fetch them). While we can work around this using the existing Nitro hooks, it means we work outside of the existing `sources` architecture. 

This PR allows us to modify the sources, allowing us to handle dynamic sitemap sources with minimal boilerplate.


```ts [server/plugins/sitemap.ts]
import { defineNitroPlugin } from 'nitropack/runtime'
import { getHeader } from 'h3'

export default defineNitroPlugin((nitroApp) => {
  nitroApp.hooks.hook('sitemap:sources', async (ctx) => {
    // Add a new source dynamically
    ctx.sources.push('/api/runtime-urls')
    
    // Modify existing sources to add headers
    ctx.sources = ctx.sources.map(source => {
      if (typeof source === 'object' && source.fetch) {
        const [url, options = {}] = Array.isArray(source.fetch) ? source.fetch : [source.fetch, {}]
        
        // Forward authorization header from original request
        const authHeader = getHeader(ctx.event, 'authorization')
        if (authHeader) {
          options.headers = options.headers || {}
          options.headers['Authorization'] = authHeader
        }
        
        source.fetch = [url, options]
      }
      return source
    })
  })
})
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
