### PR TITLE
feat: automatic chunking for multi-sitemaps (experimental)

### DIFF
--- a/docs/content/2.guides/0.multi-sitemaps.md
+++ b/docs/content/2.guides/0.multi-sitemaps.md
@@ -188,6 +188,40 @@ export default defineNuxtConfig({
 })
 ```
 
+### Chunking Large Sources
+
+When you have sources that return a large number of URLs, you can enable chunking to split them into multiple XML files:
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    sitemaps: {
+      posts: {
+        sources: ['/api/posts'], // returns 10,000 posts
+        chunks: true, // Enable chunking with default size (1000)
+      },
+      products: {
+        sources: ['/api/products'], // returns 50,000 products
+        chunks: 5000, // Chunk into files with 5000 URLs each
+      },
+      articles: {
+        sources: ['/api/articles'],
+        chunks: true,
+        chunkSize: 2000, // Alternative way to specify chunk size
+      }
+    }
+  },
+})
+```
+
+This will generate:
+- `/sitemap_index.xml` - Lists all sitemaps including chunks
+- `/posts-0.xml` - First 1000 posts
+- `/posts-1.xml` - Next 1000 posts
+- `/products-0.xml` - First 5000 products
+- `/products-1.xml` - Next 5000 products
+- etc.
+
 ### Linking External Sitemaps
 
 Use the special `index` key to add external sitemaps to your sitemap index:

--- a/docs/content/2.guides/9.chunking-sources.md
+++ b/docs/content/2.guides/9.chunking-sources.md
@@ -1,0 +1,333 @@
+---
+title: Chunking Sources
+description: Learn how to chunk large sitemap sources into multiple files for better performance and search engine compliance.
+---
+
+When working with large datasets, you may need to split your sitemap sources into multiple files to stay within search engine limits and improve performance.
+
+## Why Use Chunking?
+
+- Search engines have limits on sitemap file size (50MB) and URL count (50,000)
+- Large sitemaps can be slow to generate and parse
+- Chunked sitemaps are easier to debug and manage
+- Better performance for both generation and crawling
+- Prevents memory issues with extremely large datasets
+
+## Basic Configuration
+
+Enable chunking for any named sitemap that has sources:
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    sitemaps: {
+      posts: {
+        sources: ['/api/posts'],
+        chunks: true, // Enable chunking with default size
+      }
+    }
+  }
+})
+```
+
+## Chunk Size Configuration
+
+You can specify chunk sizes in multiple ways:
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    // Global default chunk size
+    defaultSitemapsChunkSize: 5000,
+    
+    sitemaps: {
+      // Option 1: Boolean (uses defaultSitemapsChunkSize)
+      posts: {
+        sources: ['/api/posts'],
+        chunks: true, // Uses default: 1000 or defaultSitemapsChunkSize
+      },
+      
+      // Option 2: Number as chunk size
+      products: {
+        sources: ['/api/products'],
+        chunks: 5000, // 5000 URLs per chunk
+      },
+      
+      // Option 3: Explicit chunkSize (takes precedence)
+      articles: {
+        sources: ['/api/articles'],
+        chunks: true,
+        chunkSize: 2000, // Takes precedence over chunks value
+      }
+    }
+  }
+})
+```
+
+### Precedence Rules
+
+1. `chunkSize` property takes highest precedence
+2. `chunks` number value is used if `chunkSize` not specified
+3. `defaultSitemapsChunkSize` is used if `chunks: true`
+4. Default is 1000 if no configuration provided
+
+## Real-World Examples
+
+### E-commerce Site
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    defaultSitemapsChunkSize: 10000,
+    sitemaps: {
+      // Product catalog with 100,000+ items
+      products: {
+        sources: ['/api/products/all'],
+        chunks: 10000, // Split into 10k chunks
+        defaults: {
+          changefreq: 'weekly',
+          priority: 0.8
+        }
+      },
+      // Categories with fewer items
+      categories: {
+        sources: ['/api/categories'],
+        chunks: true, // Uses default 10k
+        defaults: {
+          changefreq: 'monthly',
+          priority: 0.9
+        }
+      },
+      // Regular pages without chunking
+      pages: {
+        includeAppSources: true,
+        exclude: ['/products/**', '/categories/**']
+      }
+    }
+  }
+})
+```
+
+### Blog/Content Site
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    sitemaps: {
+      // Thousands of blog posts
+      'blog-posts': {
+        sources: ['/api/blog/posts'],
+        chunks: 5000,
+        defaults: {
+          changefreq: 'weekly',
+          priority: 0.7
+        }
+      },
+      // Author pages
+      authors: {
+        sources: ['/api/authors'],
+        chunks: false, // Explicitly disable chunking
+      },
+      // News articles with date-based chunking
+      news: {
+        sources: [
+          '/api/news/2024',
+          '/api/news/2023'
+        ],
+        chunks: 2500,
+      }
+    }
+  }
+})
+```
+
+## Generated Files
+
+When chunking is enabled, the module generates:
+
+```
+/sitemap_index.xml      # Master index including all chunks
+/products-0.xml         # First chunk (URLs 1-10,000)
+/products-1.xml         # Second chunk (URLs 10,001-20,000)
+/products-2.xml         # Third chunk (URLs 20,001-30,000)
+...
+/blog-posts-0.xml       # First chunk (URLs 1-5,000)
+/blog-posts-1.xml       # Second chunk (URLs 5,001-10,000)
+...
+/pages.xml              # Regular sitemap without chunking
+```
+
+## API Implementation
+
+### Basic Source Endpoint
+
+```ts [server/api/products/all.ts]
+export default defineEventHandler(async () => {
+  const products = await db.products.findAll({
+    select: ['id', 'slug', 'updatedAt', 'images']
+  })
+  
+  return products.map(product => ({
+    loc: `/products/${product.slug}`,
+    lastmod: product.updatedAt,
+    images: product.images?.map(img => ({
+      loc: img.url,
+      title: img.alt
+    }))
+  }))
+})
+```
+
+### Optimized for Large Datasets
+
+```ts [server/api/products/all.ts]
+export default defineCachedEventHandler(async () => {
+  // Use streaming/cursor for very large datasets
+  const products = []
+  const cursor = db.products.cursor({
+    select: ['slug', 'updatedAt']
+  })
+  
+  for await (const product of cursor) {
+    products.push({
+      loc: `/products/${product.slug}`,
+      lastmod: product.updatedAt
+    })
+  }
+  
+  return products
+}, {
+  maxAge: 60 * 60, // Cache for 1 hour
+  name: 'sitemap-products',
+  getKey: () => 'all'
+})
+```
+
+## Important Notes
+
+### What Gets Chunked
+
+- **Sources**: URLs from API endpoints are chunked
+- **Direct URLs**: URLs specified in the `urls` property are NOT chunked
+- **Mixed**: When using both, only source URLs are chunked
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    sitemaps: {
+      mixed: {
+        urls: ['/page-1', '/page-2'], // These stay in main sitemap
+        sources: ['/api/dynamic'],    // These get chunked
+        chunks: true
+      }
+    }
+  }
+})
+```
+
+### Edge Cases
+
+1. **Empty Sources**: No chunks are created for empty sources
+2. **Single URL**: Creates one chunk with one URL
+3. **Exact Division**: 10 URLs with chunkSize: 5 creates exactly 2 chunks
+4. **Invalid Values**: Negative numbers or zero are ignored
+
+### Performance Considerations
+
+1. **Memory Usage**: Chunks help manage memory for large datasets
+2. **Generation Time**: Chunks are generated on-demand, not all at once
+3. **Caching**: Each chunk is cached independently
+4. **Source Fetching**: Sources are fetched once and shared across chunks
+
+## Debugging
+
+Enable debug mode to inspect chunking behavior:
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    debug: true,
+    sitemaps: {
+      products: {
+        sources: ['/api/products'],
+        chunks: 5000
+      }
+    }
+  }
+})
+```
+
+Visit `/__sitemap__/debug.json` to see:
+- Chunk configuration details
+- Number of chunks generated
+- URLs per chunk
+- Source fetch timing
+
+### Debug Output Example
+
+```json
+{
+  "sitemaps": {
+    "products": {
+      "chunks": 5000,
+      "_isChunking": true,
+      "_chunkSize": 5000,
+      "_chunkCount": 3,
+      "sources": [
+        {
+          "fetch": "/api/products",
+          "urls": 12500,
+          "timeTakenMs": 234
+        }
+      ]
+    }
+  }
+}
+```
+
+## Best Practices
+
+1. **Choose Appropriate Chunk Sizes**
+   - Consider your server's memory limits
+   - Balance between file size and number of files
+   - Stay well below the 50k URL limit (recommend 10-25k)
+
+2. **Optimize Source Endpoints**
+   - Return only necessary fields for sitemaps
+   - Use database indexes for sorting
+   - Implement caching for expensive queries
+
+3. **Monitor Performance**
+   - Track generation times
+   - Monitor memory usage
+   - Check crawler access patterns
+
+4. **Error Handling**
+   - Sources that fail won't break chunking
+   - Empty chunks are handled gracefully
+   - Invalid configurations fall back to defaults
+
+## Migration Guide
+
+If you're upgrading from a non-chunked setup:
+
+```ts
+// Before
+export default defineNuxtConfig({
+  sitemap: {
+    sources: ['/api/all-urls'] // 100k+ URLs in one file
+  }
+})
+
+// After
+export default defineNuxtConfig({
+  sitemap: {
+    sitemaps: {
+      main: {
+        sources: ['/api/all-urls'],
+        chunks: 10000 // Split into manageable chunks
+      }
+    }
+  }
+})
+```

--- a/docs/content/2.guides/9.chunking-sources.md
+++ b/docs/content/2.guides/9.chunking-sources.md
@@ -1,188 +1,136 @@
 ---
-title: Chunking Sources
-description: Learn how to chunk large sitemap sources into multiple files for better performance and search engine compliance.
+title: Sitemap Chunking
+description: Split large sitemap sources into multiple files for performance and search engine limits.
 ---
 
-When working with large datasets, you may need to split your sitemap sources into multiple files to stay within search engine limits and improve performance.
+## Introduction
 
-## Why Use Chunking?
+When dealing with large datasets, sitemap sources can be chunked into multiple files to:
+- Stay within search engine limits (50MB file size, 50,000 URLs)
+- Improve generation performance
+- Better manage memory usage
 
-- Search engines have limits on sitemap file size (50MB) and URL count (50,000)
-- Large sitemaps can be slow to generate and parse
-- Chunked sitemaps are easier to debug and manage
-- Better performance for both generation and crawling
-- Prevents memory issues with extremely large datasets
+## Simple Configuration
 
-## Basic Configuration
+Enable chunking on any named sitemap with sources:
 
-Enable chunking for any named sitemap that has sources:
-
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   sitemap: {
     sitemaps: {
       posts: {
         sources: ['/api/posts'],
-        chunks: true, // Enable chunking with default size
+        chunks: true, // Uses default size of 1000
       }
     }
   }
 })
 ```
 
-## Chunk Size Configuration
+This generates:
+```
+/sitemap_index.xml    # Master index
+/posts-0.xml          # First chunk (1-1000)
+/posts-1.xml          # Second chunk (1001-2000)
+...
+```
 
-You can specify chunk sizes in multiple ways:
+## Chunk Size Options
 
-```ts
+Configure chunk sizes using different approaches:
+
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   sitemap: {
-    // Global default chunk size
+    // Global default
     defaultSitemapsChunkSize: 5000,
     
     sitemaps: {
-      // Option 1: Boolean (uses defaultSitemapsChunkSize)
+      // Using boolean (applies default)
       posts: {
         sources: ['/api/posts'],
-        chunks: true, // Uses default: 1000 or defaultSitemapsChunkSize
+        chunks: true,
       },
       
-      // Option 2: Number as chunk size
+      // Using number as size
       products: {
         sources: ['/api/products'],
-        chunks: 5000, // 5000 URLs per chunk
+        chunks: 10000,
       },
       
-      // Option 3: Explicit chunkSize (takes precedence)
+      // Using explicit chunkSize (highest priority)
       articles: {
         sources: ['/api/articles'],
         chunks: true,
-        chunkSize: 2000, // Takes precedence over chunks value
+        chunkSize: 2000,
       }
     }
   }
 })
 ```
 
-### Precedence Rules
-
-1. `chunkSize` property takes highest precedence
-2. `chunks` number value is used if `chunkSize` not specified
-3. `defaultSitemapsChunkSize` is used if `chunks: true`
-4. Default is 1000 if no configuration provided
-
-## Real-World Examples
+## Practical Examples
 
 ### E-commerce Site
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   sitemap: {
     defaultSitemapsChunkSize: 10000,
     sitemaps: {
-      // Product catalog with 100,000+ items
       products: {
         sources: ['/api/products/all'],
-        chunks: 10000, // Split into 10k chunks
-        defaults: {
-          changefreq: 'weekly',
-          priority: 0.8
-        }
+        chunks: 2000,
       },
-      // Categories with fewer items
       categories: {
         sources: ['/api/categories'],
         chunks: true, // Uses default 10k
-        defaults: {
-          changefreq: 'monthly',
-          priority: 0.9
-        }
-      },
-      // Regular pages without chunking
-      pages: {
-        includeAppSources: true,
-        exclude: ['/products/**', '/categories/**']
       }
     }
   }
 })
 ```
 
-### Blog/Content Site
+### Large Content Site
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   sitemap: {
     sitemaps: {
-      // Thousands of blog posts
       'blog-posts': {
         sources: ['/api/blog/posts'],
         chunks: 5000,
-        defaults: {
-          changefreq: 'weekly',
-          priority: 0.7
-        }
       },
-      // Author pages
       authors: {
         sources: ['/api/authors'],
-        chunks: false, // Explicitly disable chunking
-      },
-      // News articles with date-based chunking
-      news: {
-        sources: [
-          '/api/news/2024',
-          '/api/news/2023'
-        ],
-        chunks: 2500,
+        chunks: false, // Explicitly disable
       }
     }
   }
 })
 ```
 
-## Generated Files
+## Source Implementation
 
-When chunking is enabled, the module generates:
-
-```
-/sitemap_index.xml      # Master index including all chunks
-/products-0.xml         # First chunk (URLs 1-10,000)
-/products-1.xml         # Second chunk (URLs 10,001-20,000)
-/products-2.xml         # Third chunk (URLs 20,001-30,000)
-...
-/blog-posts-0.xml       # First chunk (URLs 1-5,000)
-/blog-posts-1.xml       # Second chunk (URLs 5,001-10,000)
-...
-/pages.xml              # Regular sitemap without chunking
-```
-
-## API Implementation
-
-### Basic Source Endpoint
+Basic endpoint for sitemap sources:
 
 ```ts [server/api/products/all.ts]
 export default defineEventHandler(async () => {
   const products = await db.products.findAll({
-    select: ['id', 'slug', 'updatedAt', 'images']
+    select: ['id', 'slug', 'updatedAt']
   })
   
   return products.map(product => ({
     loc: `/products/${product.slug}`,
-    lastmod: product.updatedAt,
-    images: product.images?.map(img => ({
-      loc: img.url,
-      title: img.alt
-    }))
+    lastmod: product.updatedAt
   }))
 })
 ```
 
-### Optimized for Large Datasets
+For large datasets, use caching and streaming:
 
 ```ts [server/api/products/all.ts]
 export default defineCachedEventHandler(async () => {
-  // Use streaming/cursor for very large datasets
   const products = []
   const cursor = db.products.cursor({
     select: ['slug', 'updatedAt']
@@ -197,53 +145,16 @@ export default defineCachedEventHandler(async () => {
   
   return products
 }, {
-  maxAge: 60 * 60, // Cache for 1 hour
-  name: 'sitemap-products',
-  getKey: () => 'all'
+  maxAge: 60 * 60, // 1 hour cache
+  name: 'sitemap-products'
 })
 ```
-
-## Important Notes
-
-### What Gets Chunked
-
-- **Sources**: URLs from API endpoints are chunked
-- **Direct URLs**: URLs specified in the `urls` property are NOT chunked
-- **Mixed**: When using both, only source URLs are chunked
-
-```ts
-export default defineNuxtConfig({
-  sitemap: {
-    sitemaps: {
-      mixed: {
-        urls: ['/page-1', '/page-2'], // These stay in main sitemap
-        sources: ['/api/dynamic'],    // These get chunked
-        chunks: true
-      }
-    }
-  }
-})
-```
-
-### Edge Cases
-
-1. **Empty Sources**: No chunks are created for empty sources
-2. **Single URL**: Creates one chunk with one URL
-3. **Exact Division**: 10 URLs with chunkSize: 5 creates exactly 2 chunks
-4. **Invalid Values**: Negative numbers or zero are ignored
-
-### Performance Considerations
-
-1. **Memory Usage**: Chunks help manage memory for large datasets
-2. **Generation Time**: Chunks are generated on-demand, not all at once
-3. **Caching**: Each chunk is cached independently
-4. **Source Fetching**: Sources are fetched once and shared across chunks
 
 ## Debugging
 
-Enable debug mode to inspect chunking behavior:
+Check chunk configuration and performance:
 
-```ts
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   sitemap: {
     debug: true,
@@ -257,77 +168,4 @@ export default defineNuxtConfig({
 })
 ```
 
-Visit `/__sitemap__/debug.json` to see:
-- Chunk configuration details
-- Number of chunks generated
-- URLs per chunk
-- Source fetch timing
-
-### Debug Output Example
-
-```json
-{
-  "sitemaps": {
-    "products": {
-      "chunks": 5000,
-      "_isChunking": true,
-      "_chunkSize": 5000,
-      "_chunkCount": 3,
-      "sources": [
-        {
-          "fetch": "/api/products",
-          "urls": 12500,
-          "timeTakenMs": 234
-        }
-      ]
-    }
-  }
-}
-```
-
-## Best Practices
-
-1. **Choose Appropriate Chunk Sizes**
-   - Consider your server's memory limits
-   - Balance between file size and number of files
-   - Stay well below the 50k URL limit (recommend 10-25k)
-
-2. **Optimize Source Endpoints**
-   - Return only necessary fields for sitemaps
-   - Use database indexes for sorting
-   - Implement caching for expensive queries
-
-3. **Monitor Performance**
-   - Track generation times
-   - Monitor memory usage
-   - Check crawler access patterns
-
-4. **Error Handling**
-   - Sources that fail won't break chunking
-   - Empty chunks are handled gracefully
-   - Invalid configurations fall back to defaults
-
-## Migration Guide
-
-If you're upgrading from a non-chunked setup:
-
-```ts
-// Before
-export default defineNuxtConfig({
-  sitemap: {
-    sources: ['/api/all-urls'] // 100k+ URLs in one file
-  }
-})
-
-// After
-export default defineNuxtConfig({
-  sitemap: {
-    sitemaps: {
-      main: {
-        sources: ['/api/all-urls'],
-        chunks: 10000 // Split into manageable chunks
-      }
-    }
-  }
-})
-```
+Visit `/__sitemap__/debug.json` to see chunk details and generation metrics.

--- a/docs/content/4.api/0.config.md
+++ b/docs/content/4.api/0.config.md
@@ -58,14 +58,125 @@ If the `lastmod` date can't be inferred from a route page file it will use the c
 
 Whether to generate multiple sitemaps.
 
+Each sitemap can have the following options:
+
+### SitemapConfig
+
+#### `sources`
+- Type: `SitemapSource[]`
+- Default: `[]`
+
+Data sources for this specific sitemap.
+
+#### `chunks`
+- Type: `boolean | number`
+- Default: `undefined`
+
+Enable chunking for sitemap sources. This splits large collections of URLs from sources into multiple smaller sitemap files to stay within search engine limits.
+
+- Set to `true` to enable chunking with the default chunk size (from `defaultSitemapsChunkSize` or 1000)
+- Set to a positive number to use that as the chunk size (e.g., `5000` for 5000 URLs per chunk)
+- Set to `false` or leave undefined to disable chunking
+
+Note: Chunking only applies to URLs from `sources`. Direct URLs in the `urls` property are not chunked.
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    sitemaps: {
+      products: {
+        sources: ['/api/products'],
+        chunks: 5000 // Split into files with 5000 URLs each
+      }
+    }
+  }
+})
+```
+
+#### `chunkSize`
+- Type: `number`
+- Default: `undefined`
+
+Explicitly set the chunk size for this sitemap. Takes precedence over the `chunks` property when both are specified.
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    sitemaps: {
+      posts: {
+        sources: ['/api/posts'],
+        chunks: true,    // Enable chunking
+        chunkSize: 2500  // Use 2500 URLs per chunk
+      }
+    }
+  }
+})
+```
+
+See the [Chunking Sources](/sitemap/guides/chunking-sources) guide for more details.
+
+#### `urls`
+- Type: `string[] | (() => string[] | Promise<string[]>)`
+- Default: `[]`
+
+Static URLs to include in this sitemap.
+
+#### `include`
+- Type: `(string | RegExp)[]`
+- Default: `undefined`
+
+Filter URLs to include in this sitemap.
+
+#### `exclude`
+- Type: `(string | RegExp)[]`
+- Default: `undefined` 
+
+Filter URLs to exclude from this sitemap.
+
+#### `defaults`
+- Type: `SitemapItemDefaults`
+- Default: `{}`
+
+Default values for all URLs in this sitemap.
+
+#### `includeAppSources`
+- Type: `boolean`
+- Default: `false`
+
+Whether to include automatic app sources in this sitemap.
+
 See [Multi Sitemaps](/docs/sitemap/guides/multi-sitemaps) for details.
 
 ## `defaultSitemapsChunkSize`
 
-- Type: `number`
+- Type: `number | false`
 - Default: `1000`
 
-When using `sitemaps: true` this will be the default chunk size for each sitemap.
+The default chunk size when chunking is enabled for multi-sitemaps. This value is used when:
+- A sitemap has `chunks: true` (without specifying a number)
+- No `chunkSize` is explicitly set for the sitemap
+
+Set to `false` to disable chunking by default for all sitemaps.
+
+```ts
+export default defineNuxtConfig({
+  sitemap: {
+    defaultSitemapsChunkSize: 5000,
+    sitemaps: {
+      // These will use 5000 as chunk size
+      posts: {
+        sources: ['/api/posts'],
+        chunks: true
+      },
+      // This overrides the default
+      products: {
+        sources: ['/api/products'],
+        chunks: 10000
+      }
+    }
+  }
+})
+```
 
 ## `defaults`
 

--- a/src/runtime/server/routes/sitemap/[sitemap].xml.ts
+++ b/src/runtime/server/routes/sitemap/[sitemap].xml.ts
@@ -7,20 +7,103 @@ export default defineEventHandler(async (e) => {
   const runtimeConfig = useSitemapRuntimeConfig(e)
   const { sitemaps } = runtimeConfig
 
-  const sitemapName = withoutLeadingSlash(withoutTrailingSlash((getRouterParam(e, 'sitemap') || e.path)?.replace('.xml', '')
+  // Extract the sitemap name from the path
+  let sitemapName = getRouterParam(e, 'sitemap')
+  if (!sitemapName) {
+    // Use the path to extract the sitemap name
+    const path = e.path
+    // Handle both regular paths and debug prefix
+    const match = path.match(/(?:\/__sitemap__\/)?([^/]+)\.xml$/)
+    if (match) {
+      sitemapName = match[1]
+    }
+  }
+
+  if (!sitemapName) {
+    return createError({
+      statusCode: 400,
+      message: 'Invalid sitemap request',
+    })
+  }
+
+  // Clean up the sitemap name
+  sitemapName = withoutLeadingSlash(withoutTrailingSlash(sitemapName.replace('.xml', '')
+    .replace('__sitemap__/', '')
     .replace(runtimeConfig.sitemapsPathPrefix || '', '')))
-  // check if sitemapName can be cast to a number safely
-  const isChunking = typeof sitemaps.chunks !== 'undefined' && !Number.isNaN(Number(sitemapName))
-  if (!sitemapName || (!(sitemapName in sitemaps) && !isChunking)) {
+
+  // Check if this is an auto-chunked sitemap (numeric name)
+  const isAutoChunking = typeof sitemaps.chunks !== 'undefined' && !Number.isNaN(Number(sitemapName))
+
+  // Check if this is a chunked named sitemap (format: name-number)
+  let isNamedChunking = false
+  let baseSitemapName = sitemapName
+  let chunkIndex: number | undefined
+
+  if (sitemapName.includes('-')) {
+    const parts = sitemapName.split('-')
+    const lastPart = parts.pop()
+    if (!Number.isNaN(Number(lastPart))) {
+      baseSitemapName = parts.join('-')
+      chunkIndex = Number(lastPart)
+      // Check if the base sitemap has chunking enabled
+      const baseSitemapConfig = sitemaps[baseSitemapName]
+      if (baseSitemapConfig && (baseSitemapConfig.chunks || baseSitemapConfig._isChunking)) {
+        isNamedChunking = true
+      }
+      // If trying to access chunk of non-chunked sitemap, return 404
+      else if (baseSitemapConfig && !(baseSitemapConfig.chunks || baseSitemapConfig._isChunking)) {
+        return createError({
+          statusCode: 404,
+          message: `Sitemap "${baseSitemapName}" does not support chunking.`,
+        })
+      }
+    }
+  }
+
+  // Check if sitemap exists
+  if (!sitemapName || (!(sitemapName in sitemaps) && !(baseSitemapName in sitemaps) && !isAutoChunking)) {
     return createError({
       statusCode: 404,
       message: `Sitemap "${sitemapName}" not found.`,
     })
   }
-  return createSitemap(e, isChunking
-    ? {
-        ...sitemaps.chunks,
-        sitemapName,
+
+  let sitemapConfig
+  if (isAutoChunking) {
+    // Auto-chunked sitemap
+    sitemapConfig = {
+      ...sitemaps.chunks,
+      sitemapName,
+    }
+  }
+  else if (isNamedChunking) {
+    // Chunked named sitemap
+    const baseSitemap = sitemaps[baseSitemapName]
+    const chunkSize = typeof baseSitemap.chunks === 'number'
+      ? baseSitemap.chunks
+      : (baseSitemap.chunkSize || runtimeConfig.defaultSitemapsChunkSize || 1000)
+
+    // Early validation of chunk index
+    if (chunkIndex !== undefined && baseSitemap._chunkCount !== undefined) {
+      if (chunkIndex >= baseSitemap._chunkCount) {
+        return createError({
+          statusCode: 404,
+          message: `Chunk ${chunkIndex} does not exist for sitemap "${baseSitemapName}".`,
+        })
       }
-    : sitemaps[sitemapName], runtimeConfig)
+    }
+
+    sitemapConfig = {
+      ...baseSitemap,
+      sitemapName, // Use the full name with chunk index
+      _isChunking: true,
+      _chunkSize: chunkSize,
+    }
+  }
+  else {
+    // Regular sitemap
+    sitemapConfig = sitemaps[sitemapName]
+  }
+
+  return createSitemap(e, sitemapConfig, runtimeConfig)
 })

--- a/src/runtime/server/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/server/sitemap/builder/sitemap-index.ts
@@ -10,7 +10,7 @@ import type {
   SitemapSourcesHookCtx,
 } from '../../../types'
 import { normaliseDate } from '../urlset/normalise'
-import { globalSitemapSources, resolveSitemapSources } from '../urlset/sources'
+import { globalSitemapSources, childSitemapSources, resolveSitemapSources } from '../urlset/sources'
 import { sortSitemapUrls } from '../urlset/sort'
 import { escapeValueForXml, wrapSitemapXml } from './xml'
 import { resolveSitemapEntries } from './sitemap'
@@ -73,16 +73,33 @@ export async function buildSitemapIndex(resolvers: NitroUrlResolvers, runtimeCon
     })
   }
   else {
-    for (const sitemap in sitemaps) {
-      if (sitemap !== 'index') {
-        // user provided sitemap config
-        chunks[sitemap] = chunks[sitemap] || { urls: [] }
+    // Process non-index sitemaps
+    for (const sitemapName in sitemaps) {
+      if (sitemapName !== 'index') {
+        const sitemapConfig = sitemaps[sitemapName]
+
+        // Check if this sitemap should be chunked
+        if (sitemapConfig.chunks) {
+          // Determine chunk size
+          const chunkSize = typeof sitemapConfig.chunks === 'number'
+            ? sitemapConfig.chunks
+            : (sitemapConfig.chunkSize || defaultSitemapsChunkSize || 1000)
+
+          // We'll populate these chunks later in buildSitemapUrls
+          // For now, just mark that this sitemap will be chunked
+          sitemapConfig._isChunking = true
+          sitemapConfig._chunkSize = chunkSize
+        }
+        else {
+          // Non-chunked sitemap
+          chunks[sitemapName] = chunks[sitemapName] || { urls: [] }
+        }
       }
     }
   }
 
   const entries: SitemapIndexEntry[] = []
-  // normalise
+  // Process regular chunks
   for (const name in chunks) {
     const sitemap = chunks[name]
     const entry: SitemapIndexEntry = {
@@ -99,6 +116,66 @@ export async function buildSitemapIndex(resolvers: NitroUrlResolvers, runtimeCon
     if (lastmod)
       entry.lastmod = normaliseDate(lastmod)
     entries.push(entry)
+  }
+
+  // Process chunked named sitemaps
+  for (const sitemapName in sitemaps) {
+    if (sitemapName !== 'index' && sitemaps[sitemapName]._isChunking) {
+      const sitemapConfig = sitemaps[sitemapName]
+      const chunkSize = sitemapConfig._chunkSize || defaultSitemapsChunkSize || 1000
+
+      // We need to determine how many chunks this sitemap will have
+      // This requires knowing the total count of URLs, which we'll get from sources
+      let sourcesInput = sitemapConfig.includeAppSources ? await globalSitemapSources() : []
+      sourcesInput.push(...await childSitemapSources(sitemapConfig))
+
+      // Allow hook to modify sources before resolution
+      if (nitro && resolvers.event) {
+        const ctx: SitemapSourcesHookCtx = {
+          event: resolvers.event,
+          sitemapName: sitemapConfig.sitemapName,
+          sources: sourcesInput,
+        }
+        await nitro.hooks.callHook('sitemap:sources', ctx)
+        sourcesInput = ctx.sources
+      }
+
+      const sources = await resolveSitemapSources(sourcesInput, resolvers.event)
+      const resolvedCtx: SitemapInputCtx = {
+        urls: sources.flatMap(s => s.urls),
+        sitemapName: sitemapConfig.sitemapName,
+        event: resolvers.event,
+      }
+      await nitro?.hooks.callHook('sitemap:input', resolvedCtx)
+
+      const normalisedUrls = resolveSitemapEntries(sitemapConfig, resolvedCtx.urls, { autoI18n, isI18nMapped }, resolvers)
+      const totalUrls = normalisedUrls.length
+      const chunkCount = Math.ceil(totalUrls / chunkSize)
+
+      // Create entries for each chunk
+      for (let i = 0; i < chunkCount; i++) {
+        const chunkName = `${sitemapName}-${i}`
+        const entry: SitemapIndexEntry = {
+          _sitemapName: chunkName,
+          sitemap: resolvers.canonicalUrlResolver(joinURL(sitemapsPathPrefix || '', `/${chunkName}.xml`)),
+        }
+
+        // Get the URLs for this chunk to find lastmod
+        const chunkUrls = normalisedUrls.slice(i * chunkSize, (i + 1) * chunkSize)
+        let lastmod = chunkUrls
+          .filter(a => !!a?.lastmod)
+          .map(a => typeof a.lastmod === 'string' ? new Date(a.lastmod) : a.lastmod)
+          .sort((a?: Date, b?: Date) => (b?.getTime() || 0) - (a?.getTime() || 0))?.[0]
+
+        if (!lastmod && autoLastmod)
+          lastmod = new Date()
+
+        if (lastmod)
+          entry.lastmod = normaliseDate(lastmod)
+
+        entries.push(entry)
+      }
+    }
   }
 
   // allow extending the index sitemap

--- a/src/runtime/server/sitemap/utils/chunk.ts
+++ b/src/runtime/server/sitemap/utils/chunk.ts
@@ -1,0 +1,107 @@
+import type { ModuleRuntimeConfig, SitemapDefinition } from '../../../types'
+
+export interface ChunkInfo {
+  isChunked: boolean
+  baseSitemapName: string
+  chunkIndex?: number
+  chunkSize: number
+}
+
+export function parseChunkInfo(
+  sitemapName: string,
+  sitemaps: ModuleRuntimeConfig['sitemaps'],
+  defaultChunkSize: number = 1000,
+): ChunkInfo {
+  // Check if this is an auto-chunked sitemap (numeric name)
+  if (typeof sitemaps.chunks !== 'undefined' && !Number.isNaN(Number(sitemapName))) {
+    return {
+      isChunked: true,
+      baseSitemapName: 'sitemap',
+      chunkIndex: Number(sitemapName),
+      chunkSize: defaultChunkSize,
+    }
+  }
+
+  // Check if this is a chunked named sitemap (format: name-number)
+  if (sitemapName.includes('-')) {
+    const parts = sitemapName.split('-')
+    const lastPart = parts.pop()
+
+    if (!Number.isNaN(Number(lastPart))) {
+      const baseSitemapName = parts.join('-')
+      const baseSitemap = sitemaps[baseSitemapName]
+
+      if (baseSitemap && (baseSitemap.chunks || baseSitemap._isChunking)) {
+        const chunkSize = typeof baseSitemap.chunks === 'number'
+          ? baseSitemap.chunks
+          : (baseSitemap.chunkSize || defaultChunkSize)
+
+        return {
+          isChunked: true,
+          baseSitemapName,
+          chunkIndex: Number(lastPart),
+          chunkSize,
+        }
+      }
+    }
+  }
+
+  // Not a chunked sitemap
+  return {
+    isChunked: false,
+    baseSitemapName: sitemapName,
+    chunkIndex: undefined,
+    chunkSize: defaultChunkSize,
+  }
+}
+
+export function getSitemapConfig(
+  sitemapName: string,
+  sitemaps: ModuleRuntimeConfig['sitemaps'],
+  defaultChunkSize: number = 1000,
+): SitemapDefinition {
+  const chunkInfo = parseChunkInfo(sitemapName, sitemaps, defaultChunkSize)
+
+  if (chunkInfo.isChunked) {
+    // For auto-chunked sitemaps
+    if (chunkInfo.baseSitemapName === 'sitemap' && typeof sitemaps.chunks !== 'undefined') {
+      return {
+        ...sitemaps.chunks,
+        sitemapName,
+        _isChunking: true,
+        _chunkSize: chunkInfo.chunkSize,
+      }
+    }
+
+    // For named chunked sitemaps
+    const baseSitemap = sitemaps[chunkInfo.baseSitemapName]
+    if (baseSitemap) {
+      return {
+        ...baseSitemap,
+        sitemapName, // Use the full name with chunk index
+        _isChunking: true,
+        _chunkSize: chunkInfo.chunkSize,
+      }
+    }
+  }
+
+  // Regular sitemap
+  return sitemaps[sitemapName]
+}
+
+export function sliceUrlsForChunk<T>(
+  urls: T[],
+  sitemapName: string,
+  sitemaps: ModuleRuntimeConfig['sitemaps'],
+  defaultChunkSize: number = 1000,
+): T[] {
+  const chunkInfo = parseChunkInfo(sitemapName, sitemaps, defaultChunkSize)
+
+  if (chunkInfo.isChunked && chunkInfo.chunkIndex !== undefined) {
+    const startIndex = chunkInfo.chunkIndex * chunkInfo.chunkSize
+    const endIndex = (chunkInfo.chunkIndex + 1) * chunkInfo.chunkSize
+    return urls.slice(startIndex, endIndex)
+  }
+
+  return urls
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -299,9 +299,48 @@ export interface SitemapDefinition {
    */
   sources?: SitemapSourceInput[]
   /**
+   * Whether to enable chunking for this sitemap.
+   *
+   * - `true`: Enable with default chunk size from `defaultSitemapsChunkSize`
+   * - `number`: Enable with specific chunk size (must be > 0)
+   * - `false` or `undefined`: Disable chunking
+   *
+   * Note: Chunking only applies to sitemaps with sources. URLs provided directly
+   * are not chunked.
+   *
+   * @default false
+   * @example true
+   * @example 5000
+   */
+  chunks?: boolean | number
+  /**
+   * The maximum number of URLs per chunk when chunking is enabled.
+   * Takes precedence over the `chunks` property when both are specified.
+   * Also overrides the global `defaultSitemapsChunkSize`.
+   *
+   * Must be a positive integer.
+   *
+   * @default 1000
+   * @example 500
+   * @example 10000
+   */
+  chunkSize?: number
+  /**
    * @internal
    */
   _route?: string
+  /**
+   * @internal
+   */
+  _isChunking?: boolean
+  /**
+   * @internal
+   */
+  _chunkSize?: number
+  /**
+   * @internal
+   */
+  _chunkCount?: number
 }
 
 interface NitroBaseHook {

--- a/test/fixtures/multi-with-chunks/app.vue
+++ b/test/fixtures/multi-with-chunks/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Multi Sitemap Chunking Test</h1>
+  </div>
+</template>

--- a/test/fixtures/multi-with-chunks/nuxt.config.ts
+++ b/test/fixtures/multi-with-chunks/nuxt.config.ts
@@ -1,0 +1,37 @@
+import NuxtSitemap from '../../../src/module'
+
+// https://v3.nuxtjs.org/api/configuration/nuxt.config
+export default defineNuxtConfig({
+  modules: [
+    NuxtSitemap,
+  ],
+  site: {
+    url: 'https://nuxtseo.com',
+  },
+  debug: process.env.NODE_ENV === 'test',
+  sitemap: {
+    autoLastmod: false,
+    credits: false,
+    debug: true,
+    defaultSitemapsChunkSize: 5,
+    sitemaps: {
+      pages: {
+        urls: Array.from({ length: 20 }, (_, i) => `/page/${i + 1}`),
+        excludeAppSources: true,
+      },
+      posts: {
+        sources: [
+          '/api/posts',
+        ],
+        chunks: true,
+        chunkSize: 3,
+      },
+      products: {
+        sources: [
+          '/api/products',
+        ],
+        chunks: 10, // use 10 as chunk size
+      },
+    },
+  },
+})

--- a/test/fixtures/multi-with-chunks/server/api/posts.ts
+++ b/test/fixtures/multi-with-chunks/server/api/posts.ts
@@ -1,0 +1,7 @@
+export default defineEventHandler(() => {
+  // Generate 12 posts to test chunking with chunkSize: 3 (should create 4 chunks)
+  return Array.from({ length: 12 }, (_, i) => ({
+    loc: `/posts/${i + 1}`,
+    lastmod: new Date(2024, 0, i + 1).toISOString(),
+  }))
+})

--- a/test/fixtures/multi-with-chunks/server/api/posts.ts
+++ b/test/fixtures/multi-with-chunks/server/api/posts.ts
@@ -1,3 +1,5 @@
+import { defineEventHandler } from 'h3'
+
 export default defineEventHandler(() => {
   // Generate 12 posts to test chunking with chunkSize: 3 (should create 4 chunks)
   return Array.from({ length: 12 }, (_, i) => ({

--- a/test/fixtures/multi-with-chunks/server/api/products.ts
+++ b/test/fixtures/multi-with-chunks/server/api/products.ts
@@ -1,0 +1,7 @@
+export default defineEventHandler(() => {
+  // Generate 25 products to test chunking with chunkSize: 10 (should create 3 chunks)
+  return Array.from({ length: 25 }, (_, i) => ({
+    loc: `/products/${i + 1}`,
+    lastmod: new Date(2024, 1, i + 1).toISOString(),
+  }))
+})

--- a/test/fixtures/multi-with-chunks/server/api/products.ts
+++ b/test/fixtures/multi-with-chunks/server/api/products.ts
@@ -1,3 +1,5 @@
+import { defineEventHandler } from 'h3'
+
 export default defineEventHandler(() => {
   // Generate 25 products to test chunking with chunkSize: 10 (should create 3 chunks)
   return Array.from({ length: 25 }, (_, i) => ({

--- a/test/integration/multi/chunking-edge-cases.test.ts
+++ b/test/integration/multi/chunking-edge-cases.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/multi-with-chunks'),
+  server: true,
+  nuxtConfig: {
+    hooks: {
+      'nitro:config': function (config) {
+        config.runtimeConfig ??= {}
+        config.runtimeConfig.public ??= {}
+        config.runtimeConfig.public.siteUrl = 'https://nuxtseo.com'
+      },
+    },
+  },
+})
+
+describe('chunking edge cases', () => {
+  describe('empty chunks', () => {
+    it('returns 404 for non-existent chunk', async () => {
+      // The posts sitemap has 12 posts with chunkSize: 3, so it should have chunks 0-3
+      // Chunk 4 should not exist
+      try {
+        await $fetch('/__sitemap__/posts-4.xml')
+        throw new Error('Should have thrown 404')
+      }
+      catch (error: any) {
+        expect(error.data?.statusCode || error.statusCode).toBe(404)
+      }
+    })
+
+    it('returns 404 for chunk of non-chunked sitemap', async () => {
+      // pages sitemap doesn't have chunking enabled
+      try {
+        await $fetch('/__sitemap__/pages-0.xml')
+        throw new Error('Should have thrown 404')
+      }
+      catch (error: any) {
+        expect(error.data?.statusCode || error.statusCode).toBe(404)
+      }
+    })
+  })
+
+  describe('chunk boundary validation', () => {
+    it('handles last valid chunk', async () => {
+      // posts has 12 items with chunkSize: 3, so chunk 3 (the 4th chunk) is the last valid one
+      const chunk = await $fetch('/__sitemap__/posts-3.xml')
+      expect(chunk).toContain('<urlset')
+      expect(chunk).toContain('<loc>https://nuxtseo.com/posts/10</loc>')
+      expect(chunk).toContain('<loc>https://nuxtseo.com/posts/11</loc>')
+      expect(chunk).toContain('<loc>https://nuxtseo.com/posts/12</loc>')
+    })
+
+    it('handles products chunk boundaries', async () => {
+      // products has 25 items with chunkSize: 10
+      // chunk 0: 1-10, chunk 1: 11-20, chunk 2: 21-25
+
+      const chunk2 = await $fetch('/__sitemap__/products-2.xml')
+      expect(chunk2).toContain('<urlset')
+      expect(chunk2).toContain('<loc>https://nuxtseo.com/products/21</loc>')
+      expect(chunk2).toContain('<loc>https://nuxtseo.com/products/25</loc>')
+
+      // chunk 3 should not exist
+      try {
+        await $fetch('/__sitemap__/products-3.xml')
+        throw new Error('Should have thrown 404')
+      }
+      catch (error: any) {
+        expect(error.data?.statusCode || error.statusCode).toBe(404)
+      }
+    })
+  })
+})

--- a/test/integration/multi/chunking.test.ts
+++ b/test/integration/multi/chunking.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/multi-with-chunks'),
+  server: true,
+  nuxtConfig: {
+    hooks: {
+      'nitro:config': function (config) {
+        config.runtimeConfig ??= {}
+        config.runtimeConfig.public ??= {}
+        config.runtimeConfig.public.siteUrl = 'https://nuxtseo.com'
+      },
+    },
+  },
+})
+
+describe('multi sitemaps with chunking', () => {
+  it('basic index', async () => {
+    const index = await $fetch('/sitemap_index.xml')
+
+    expect(index).toContain('<sitemapindex')
+    expect(index).toContain('<loc>https://nuxtseo.com/__sitemap__/pages.xml</loc>')
+
+    // Should have 4 chunks for posts (12 posts / 3 per chunk)
+    expect(index).toContain('<loc>https://nuxtseo.com/__sitemap__/posts-0.xml</loc>')
+    expect(index).toContain('<loc>https://nuxtseo.com/__sitemap__/posts-1.xml</loc>')
+    expect(index).toContain('<loc>https://nuxtseo.com/__sitemap__/posts-2.xml</loc>')
+    expect(index).toContain('<loc>https://nuxtseo.com/__sitemap__/posts-3.xml</loc>')
+
+    // Should have 3 chunks for products (25 products / 10 per chunk)
+    expect(index).toContain('<loc>https://nuxtseo.com/__sitemap__/products-0.xml</loc>')
+    expect(index).toContain('<loc>https://nuxtseo.com/__sitemap__/products-1.xml</loc>')
+    expect(index).toContain('<loc>https://nuxtseo.com/__sitemap__/products-2.xml</loc>')
+  })
+
+  // Debug test
+  it('posts sources', async () => {
+    const posts = await $fetch('/api/posts')
+    expect(posts).toHaveLength(12)
+    expect(posts[0]).toEqual({
+      loc: '/posts/1',
+      lastmod: expect.any(String),
+    })
+  })
+
+  it('posts chunk 0', async () => {
+    const chunk = await $fetch('/__sitemap__/posts-0.xml')
+
+    expect(chunk).toContain('<urlset')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/posts/1</loc>')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/posts/2</loc>')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/posts/3</loc>')
+    expect(chunk).not.toContain('<loc>https://nuxtseo.com/posts/4</loc>')
+  })
+
+  it('posts chunk 1', async () => {
+    const chunk = await $fetch('/__sitemap__/posts-1.xml')
+
+    expect(chunk).toContain('<urlset')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/posts/4</loc>')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/posts/5</loc>')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/posts/6</loc>')
+    expect(chunk).not.toContain('<loc>https://nuxtseo.com/posts/3</loc>')
+    expect(chunk).not.toContain('<loc>https://nuxtseo.com/posts/7</loc>')
+  })
+
+  it('posts chunk 3 (last)', async () => {
+    const chunk = await $fetch('/__sitemap__/posts-3.xml')
+
+    expect(chunk).toContain('<urlset')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/posts/10</loc>')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/posts/11</loc>')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/posts/12</loc>')
+    expect(chunk).not.toContain('<loc>https://nuxtseo.com/posts/9</loc>')
+  })
+
+  it('products chunk 0', async () => {
+    const chunk = await $fetch('/__sitemap__/products-0.xml')
+
+    expect(chunk).toContain('<urlset')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/products/1</loc>')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/products/10</loc>')
+    expect(chunk).not.toContain('<loc>https://nuxtseo.com/products/11</loc>')
+  })
+
+  it('products chunk 2 (last)', async () => {
+    const chunk = await $fetch('/__sitemap__/products-2.xml')
+
+    expect(chunk).toContain('<urlset')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/products/21</loc>')
+    expect(chunk).toContain('<loc>https://nuxtseo.com/products/25</loc>')
+    expect(chunk).not.toContain('<loc>https://nuxtseo.com/products/20</loc>')
+  })
+
+  it('non-chunked pages sitemap', async () => {
+    const pages = await $fetch('/__sitemap__/pages.xml')
+
+    expect(pages).toContain('<urlset')
+    expect(pages).toContain('<loc>https://nuxtseo.com/page/1</loc>')
+    expect(pages).toContain('<loc>https://nuxtseo.com/page/20</loc>')
+  })
+
+  it('404 for non-existent chunk', async () => {
+    // Should return 404 for chunks that don't exist
+    try {
+      await $fetch('/__sitemap__/posts-4.xml')
+      throw new Error('Should have thrown 404')
+    }
+    catch (error: any) {
+      expect(error.data?.statusCode || error.statusCode).toBe(404)
+    }
+  })
+
+  it('404 for non-existent chunked sitemap', async () => {
+    // Should return 404 for sitemap that doesn't support chunking
+    try {
+      await $fetch('/__sitemap__/pages-0.xml')
+      throw new Error('Should have thrown 404')
+    }
+    catch (error: any) {
+      expect(error.data?.statusCode || error.statusCode).toBe(404)
+    }
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/nuxt-modules/sitemap/issues/265
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's common that we want to split our sitemap into different sub-sitemaps, however, when we do this we lose the ability to have them automatically chunked based on the number of entries.

This PR allows us to have automatic chunks within a sub-sitemap, allowing us to handle very large sitemaps in multiple sitemaps, allowing for improving caching, debugging and SEO performance.

Support is experimental as the i18n behavior is not fully tested.

```ts
export default defineNuxtConfig({
  sitemap: {
    sitemaps: {
      posts: {
        sources: ['/api/posts'], // returns 10,000 posts
        chunks: true, // Enable chunking with default size (1000)
      },
      products: {
        sources: ['/api/products'], // returns 50,000 products
        chunks: 5000, // Chunk into files with 5000 URLs each
      },
      articles: {
        sources: ['/api/articles'],
        chunks: true,
        chunkSize: 2000, // Alternative way to specify chunk size
      }
    }
  },
})
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
