### PR TITLE
fix: nitro compatibility with v4

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -95,9 +95,9 @@ export function setupPrerenderHandler(_options: { runtimeConfig: ModuleRuntimeCo
       }), route._sitemap) as SitemapUrl
     })
     nitro.hooks.hook('prerender:done', async () => {
-      const isNuxt4 = nuxt.options._majorVersion === 4
+      const isNuxt5 = nuxt.options._majorVersion === 5
       let nitroModule
-      if (isNuxt4) {
+      if (isNuxt5) {
         nitroModule = await import(String('nitro'))
       }
       else {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Resolves: https://github.com/nuxt-modules/sitemap/issues/453

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

[This PR](https://github.com/nuxt/nuxt/pull/32252) reverted the Nitro version included in Nuxt. This means we still need to use the `nitropack` import until Nitro v3 is reintroduced (hopefully in Nuxt v5). 
