### PR TITLE
fix: expose site config on debug endpoint

### DIFF
--- a/src/runtime/server/routes/__sitemap__/debug.ts
+++ b/src/runtime/server/routes/__sitemap__/debug.ts
@@ -6,16 +6,17 @@ import {
   globalSitemapSources,
   resolveSitemapSources,
 } from '../../sitemap/urlset/sources'
-import { useNitroOrigin } from '#site-config/server/composables/useNitroOrigin'
+import { getNitroOrigin, getSiteConfig } from '#site-config/server/composables'
 
 export default defineEventHandler(async (e) => {
   const _runtimeConfig = useSitemapRuntimeConfig()
+  const siteConfig = getSiteConfig(e)
   const { sitemaps: _sitemaps } = _runtimeConfig
   const runtimeConfig = { ..._runtimeConfig }
   // @ts-expect-error hack
   delete runtimeConfig.sitemaps
   const globalSources = await globalSitemapSources()
-  const nitroOrigin = useNitroOrigin(e)
+  const nitroOrigin = getNitroOrigin(e)
   const sitemaps: Record<string, SitemapDefinition> = {}
   for (const s of Object.keys(_sitemaps)) {
     // resolve the sources
@@ -29,5 +30,6 @@ export default defineEventHandler(async (e) => {
     sitemaps,
     runtimeConfig,
     globalSources: await resolveSitemapSources(globalSources, e),
+    siteConfig: { ...siteConfig },
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Could help resolve situations like this perhaps https://github.com/nuxt-modules/sitemap/issues/466

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Just adding more of the website's configurations to the debug page for more in depth debugging out the sitemap output.

Also replaced a deprecated function call while I was there
