### PR TITLE
fix(nuxt content v3 integration): fix import

### DIFF
--- a/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
+++ b/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler } from 'h3'
-import { queryCollection } from '@nuxt/content/server'
+import { queryCollection } from '@nuxt/content/nitro'
 // @ts-expect-error alias
 import manifest from '#content/manifest'
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolved #497

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

fix the import of queryCollection for nuxt content v3 integration.
Imported from "server" instead of "nitro".
"server" not exists in the nuxt content v3 export