### PR TITLE
docs: remove buggy codeblocks

### DIFF
--- a/docs/content/2.guides/2.images-videos.md
+++ b/docs/content/2.guides/2.images-videos.md
@@ -150,8 +150,6 @@ Like automatic image discovery, you can opt-in to automatic video discovery incl
 
 You are also required to provide a title and description for your video, this can be done using the `data-title` and `data-description` attributes.
 
-::code-block
-
 ```html [Simple]
 <video
     controls
@@ -188,8 +186,6 @@ You are also required to provide a title and description for your video, this ca
     
 >   
 ```
-
-::
 
 Each format would be added to your sitemap in the following format:
 


### PR DESCRIPTION
Looks like the codeblocks here is breaking the code? :)
https://nuxtseo.com/docs/sitemap/guides/images-videos

<img width="1680" height="1046" alt="CleanShot 2025-10-07 at 10 18 51@2x" src="https://github.com/user-attachments/assets/e191e116-4b04-494f-b5f1-20037c441eea" />
