### PR TITLE
fix: honour excludeAppSources added after setup

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -45,7 +45,7 @@ import {
   splitPathForI18nLocales,
 } from './utils-internal/i18n'
 import { createNitroPromise, createPagesPromise, getNuxtModuleOptions, isNuxtGenerate, resolveNitroPreset, resolveNuxtContentVersion } from './utils-internal/kit'
-import { convertNuxtPagesToSitemapEntries, generateExtraRoutesFromNuxtConfig, resolveUrls } from './utils-internal/nuxtSitemap'
+import { convertNuxtPagesToSitemapEntries, generateExtraRoutesFromNuxtConfig, resolveExcludedAppSources, resolveUrls } from './utils-internal/nuxtSitemap'
 
 declare global {
   // eslint-disable-next-line vars-on-top
@@ -862,6 +862,12 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     const generateGlobalSources = async () => {
+      // Read the authored config again, so a module that set up after this one can
+      // still exclude an app source. See resolveExcludedAppSources.
+      const excludedAppSources = resolveExcludedAppSources(
+        config.excludeAppSources,
+        (nuxt.options as { sitemap?: { excludeAppSources?: unknown } }).sitemap?.excludeAppSources,
+      )
       const { routeRules } = generateExtraRoutesFromNuxtConfig()
       const nitro = await nitroPromise
       const prerenderedRoutes = nitro._prerenderedRoutes || []
@@ -951,7 +957,7 @@ export default defineNuxtModule<ModuleOptions>({
           s.sourceType = 'user'
           return s
         }),
-        ...(config.excludeAppSources === true
+        ...(excludedAppSources === true
           ? []
           : <typeof appGlobalSources>[
             ...appGlobalSources,
@@ -987,7 +993,7 @@ export default defineNuxtModule<ModuleOptions>({
             },
           ])
           .filter(s =>
-            !(config.excludeAppSources as AppSourceContext[]).includes(s.context.name as AppSourceContext)
+            !(excludedAppSources as AppSourceContext[]).includes(s.context.name as AppSourceContext)
             && (!!s.urls?.length || !!s.fetch))
           .map((s) => {
             s.sourceType = 'app'

--- a/src/utils-internal/nuxtSitemap.ts
+++ b/src/utils-internal/nuxtSitemap.ts
@@ -1,7 +1,7 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { ConsolaInstance } from 'consola'
 import type { NuxtPage } from 'nuxt/schema'
-import type { AutoI18nConfig, FilterInput, SitemapDefinition, SitemapUrl, SitemapUrlInput } from '../runtime/types'
+import type { AppSourceContext, AutoI18nConfig, FilterInput, SitemapDefinition, SitemapUrl, SitemapUrlInput } from '../runtime/types'
 import { statSync } from 'node:fs'
 import { useNuxt } from '@nuxt/kit'
 import { defu } from 'defu'
@@ -234,4 +234,28 @@ export function generateExtraRoutesFromNuxtConfig(nuxt: Nuxt = useNuxt()) {
     .map(([k]) => k)
     .filter(filterForValidPage)
   return { routeRules }
+}
+
+/**
+ * Resolve the app sources to exclude, honouring exclusions added after this module set up.
+ *
+ * `defineNuxtModule` hands `setup` a fresh object from `defu(...)` and never writes it
+ * back to `nuxt.options.sitemap`, so a module that loads after this one cannot reach
+ * the config we resolved. App sources are built lazily, well after every module has
+ * set up, so the two lists are unioned at that point instead.
+ */
+export function resolveExcludedAppSources(
+  resolved: true | AppSourceContext[],
+  authored: unknown,
+): true | AppSourceContext[] {
+  if (resolved === true || authored === true)
+    return true
+  if (!Array.isArray(authored))
+    return resolved
+  const excluded = [...resolved]
+  for (const source of authored) {
+    if (typeof source === 'string' && !excluded.includes(source as AppSourceContext))
+      excluded.push(source as AppSourceContext)
+  }
+  return excluded
 }

--- a/test/e2e/single/lateExcludeAppSources.test.ts
+++ b/test/e2e/single/lateExcludeAppSources.test.ts
@@ -1,0 +1,37 @@
+import { createResolver, defineNuxtModule } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+// Modules that load after @nuxtjs/sitemap only ever see `nuxt.options.sitemap`.
+// `defineNuxtModule` hands each module its own resolved copy, so this exclusion
+// cannot reach the config the sitemap module already resolved.
+const excludePagesLate = defineNuxtModule({
+  meta: { name: 'test-late-exclude' },
+  setup(_options, nuxt) {
+    const sitemap = (nuxt.options as { sitemap?: { excludeAppSources?: string[] } }).sitemap
+    sitemap!.excludeAppSources = [...(sitemap!.excludeAppSources ?? []), 'nuxt:pages']
+  },
+})
+
+await setup({
+  rootDir: resolve('../../fixtures/basic'),
+  nuxtConfig: {
+    modules: [excludePagesLate],
+    sitemap: {
+      excludeAppSources: [],
+      urls: ['/only-url'],
+    },
+  },
+})
+
+describe('app sources excluded after setup', () => {
+  it('honours an exclusion a later module added', async () => {
+    const sitemap = await $fetch('/sitemap.xml')
+
+    expect(sitemap).toContain('<loc>https://nuxtseo.com/only-url</loc>')
+    // /about is a static page file, so it can only arrive through nuxt:pages
+    expect(sitemap).not.toContain('/about')
+  })
+})

--- a/test/unit/resolveExcludedAppSources.test.ts
+++ b/test/unit/resolveExcludedAppSources.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { resolveExcludedAppSources } from '../../src/utils-internal/nuxtSitemap'
+
+describe('resolveExcludedAppSources', () => {
+  it('keeps the resolved exclusions when nothing was authored later', () => {
+    expect(resolveExcludedAppSources(['nuxt:pages'], undefined)).toEqual(['nuxt:pages'])
+  })
+
+  it('adds an exclusion authored after setup', () => {
+    expect(resolveExcludedAppSources([], ['@nuxt/content@v3:urls'])).toEqual(['@nuxt/content@v3:urls'])
+  })
+
+  it('unions both lists without duplicating', () => {
+    expect(resolveExcludedAppSources(['nuxt:pages'], ['nuxt:pages', 'nuxt:prerender']))
+      .toEqual(['nuxt:pages', 'nuxt:prerender'])
+  })
+
+  it('excludes everything when either side opts out entirely', () => {
+    expect(resolveExcludedAppSources(true, ['nuxt:pages'])).toBe(true)
+    expect(resolveExcludedAppSources([], true)).toBe(true)
+  })
+
+  it('ignores a malformed authored value rather than dropping the resolved list', () => {
+    expect(resolveExcludedAppSources(['nuxt:pages'], 'nuxt:prerender')).toEqual(['nuxt:pages'])
+    expect(resolveExcludedAppSources(['nuxt:pages'], [42, 'nuxt:prerender'])).toEqual(['nuxt:pages', 'nuxt:prerender'])
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`excludeAppSources` is silently ignored for any module that loads after this one.

`defineNuxtModule` resolves each module's options with `defu(inlineOptions, nuxtConfigOptions, optionsDefaults)` and never writes the result back to `nuxt.options[configKey]`, so the `config` we get in `setup` is a detached copy. A module loading later can only reach `nuxt.options.sitemap`, and by then we have already captured our own object. Its entries never reach the filter in `generateGlobalSources`.

Hit this with `@harlan-zw/comark-content`, which replaces `@nuxt/content` and so wants the `@nuxt/content@v3:urls` source gone. It does the documented thing and adds the exclusion in its `setup()`, but the site lists `@nuxtjs/seo` before it, so the source stayed. That source has a `fetch` to `/__sitemap__/nuxt-content-urls.json`, which no longer had a handler once `@nuxt/content` was uninstalled, and the 404 took the whole prerendered `/sitemap.xml` down:

```
[error] [request error] [fatal] [GET] http://localhost/__sitemap__/nuxt-content-urls.json
Page not found: /__sitemap__/nuxt-content-urls.json
[error] [@nuxt/sitemap] Failed to fetch source. { url: '/__sitemap__/nuxt-content-urls.json' }

Errors prerendering:
  ├─ /sitemap.xml (2936ms)
  │ └── [500] Server Error
```

`generateGlobalSources` is a closure invoked lazily, well after every module has set up, so it can just read the authored list again at that point and union it with the resolved one. Order stops mattering.

Kept narrow on purpose: only ever adds exclusions, and a non-array authored value is ignored rather than replacing what we resolved.

The e2e covers it end to end. It registers a module after `@nuxtjs/sitemap` that appends `nuxt:pages` to `nuxt.options.sitemap.excludeAppSources`, and asserts a static page file is gone from the output. It fails on `main` with `expected '<?xml version="1.0"...' not to contain '/about'`.

### 📚 Additional context

Worth deciding whether the `@nuxt/content` integration should register its `fetch` source at all when the package is not installed. On the site that hit this, `@nuxt/content` is removed from `package.json` and the Vercel install log shows it being pruned, yet the source is still registered there. I could not reproduce that half locally, so I have not touched the detection.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).