### PR TITLE
docs: unify sitemap source endpoint guidance

### DIFF
--- a/docs/content/0.getting-started/2.data-sources.md
+++ b/docs/content/0.getting-started/2.data-sources.md
@@ -139,7 +139,7 @@ export default defineNuxtConfig({
 
 ::
 
-You can provide multiple sources, but consider implementing your own caching strategy for performance.
+The module caches the resolved sitemap in production, so sources are not fetched on every crawler request. Add endpoint caching only when a source is slow, rate limited, or metered. See [Which handler should I use?](/docs/sitemap/guides/dynamic-urls#which-handler-should-i-use).
 
 Learn more about working with dynamic data in the [Dynamic URLs](/docs/sitemap/guides/dynamic-urls) guide.
 

--- a/docs/content/1.guides/0.dynamic-urls.md
+++ b/docs/content/1.guides/0.dynamic-urls.md
@@ -121,11 +121,39 @@ export default defineNuxtConfig({
 
 ### 2. Creating Custom Endpoints
 
-The resolved sitemap is already cached server-side for [`cacheMaxAgeSeconds`](/docs/sitemap/advanced/performance) (10 minutes by default), so your endpoint isn't hit on every crawler request. Only add your own caching in the endpoint itself if the upstream API is slow or rate-limited.
+#### Which handler should I use?
+
+Use `defineSitemapEventHandler()`{lang="ts"}. It is a typed alias for Nitro's `defineEventHandler()`{lang="ts"}. It types the return value as `SitemapUrlInput[]`{lang="ts"} so your editor checks each URL object. It adds no caching, because the module handles that for you:
+
+- The resolved sitemap is cached in production for [`cacheMaxAgeSeconds`](/docs/sitemap/advanced/performance#cache-time), 10 minutes by default. This covers source fetching, normalization and sorting.
+- All chunks of a sitemap share one cache entry, so chunking does not multiply requests to your endpoint.
+
+The module cache is disabled in development and during prerendering, so every request reaches your endpoint there.
+
+Reach for Nitro's `defineCachedEventHandler()`{lang="ts"} when your endpoint is expensive enough that one call per cache window still hurts, for example a slow, rate limited, or metered upstream API. Each named sitemap resolves its own sources, so this also helps when several sitemaps read the same endpoint. It has no sitemap-aware types, so annotate the return value:
+
+```ts [server/api/__sitemap__/urls.ts]
+import type { SitemapUrlInput } from '#sitemap/types'
+
+export default defineCachedEventHandler(async (): Promise<SitemapUrlInput[]> => {
+  const posts = await $fetch<{ slug: string, modified: string }[]>('https://slow-api.example.com/posts')
+  return posts.map(post => ({
+    loc: `/blog/${post.slug}`,
+    lastmod: post.modified,
+  }))
+}, {
+  maxAge: 60 * 60, // 1 hour
+  name: 'sitemap-posts',
+})
+```
+
+::note
+Set `maxAge` higher than `cacheMaxAgeSeconds`. A lower value has little effect, because the module cache already absorbs most requests.
+::
 
 **Step 1: Create the API endpoint**
 
-Use the [`defineSitemapEventHandler()`{lang="ts"}](/docs/sitemap/nitro-api/nitro-hooks) helper to create type-safe sitemap endpoints:
+Use the `defineSitemapEventHandler()`{lang="ts"} helper to create type-safe sitemap endpoints:
 
 ::code-group
 

--- a/docs/content/2.advanced/2.performance.md
+++ b/docs/content/2.advanced/2.performance.md
@@ -97,11 +97,11 @@ A streamed response omits `Content-Length`. `Content-Encoding: gzip` or `deflate
 
 **Very large sites (100k+ URLs).** For sites at this scale, two practices matter most:
 
-1. **Cache the source endpoint.** Use `defineCachedEventHandler` on any `/api/*` route fed into `sources`. Without this, every cache miss (and every fresh chunk) re-hits your backend.
+1. **Set generous chunk sizes.** Search engines accept up to 50,000 URLs per file. The default `defaultSitemapsChunkSize` of 1000 generates 50× more chunks than necessary; bumping to `5000`–`50000` directly reduces total work and cache entries.
 
-2. **Set generous chunk sizes.** Search engines accept up to 50,000 URLs per file. The default `defaultSitemapsChunkSize` of 1000 generates 50× more chunks than necessary; bumping to `5000`–`50000` directly reduces total work and cache entries.
+2. **Cache the source endpoint when the upstream is expensive.** [Sitemap Caching](#sitemap-caching) already keeps your `/api/*` sources off most requests. Add `defineCachedEventHandler` on top of that when the upstream API is slow, rate limited, or metered, or when several named sitemaps read the same endpoint. See [Which handler should I use?](/docs/sitemap/guides/dynamic-urls#which-handler-should-i-use).
 
-With `cacheMaxAgeSeconds` enabled in production, chunks of the same base sitemap share one resolved URL computation per cache window. If caching is disabled, each requested chunk processes the complete base URL set before slicing its own URLs. Splitting one large sitemap into per-shard sitemaps, such as one per locale or content type, is still useful when shards have different cache lifetimes or sources.
+With `cacheMaxAgeSeconds` enabled in production, chunks of the same base sitemap share one resolved URL computation per cache window, so chunking alone does not add source fetches. If caching is disabled, each requested chunk processes the complete base URL set before slicing its own URLs. Splitting one large sitemap into per-shard sitemaps, such as one per locale or content type, is still useful when shards have different cache lifetimes or sources.
 
 ## Zero Runtime Mode
 

--- a/docs/content/2.advanced/3.chunking-sources.md
+++ b/docs/content/2.advanced/3.chunking-sources.md
@@ -161,10 +161,14 @@ export default defineNuxtConfig({
 
 ## Source Implementation
 
-Basic endpoint for sitemap sources:
+Chunks of the same sitemap share one resolved URL cache entry in production, so your source endpoint is called once per [cache window](/docs/sitemap/advanced/performance#cache-time), not once per chunk. Write the endpoint the same way you would without chunking.
+
+Use `defineSitemapEventHandler()`{lang="ts"}. It types the return value as `SitemapUrlInput[]`{lang="ts"} and adds no caching of its own:
 
 ```ts [server/api/products/all.ts]
-export default defineEventHandler(async () => {
+import { defineSitemapEventHandler } from '#imports'
+
+export default defineSitemapEventHandler(async () => {
   const products = await db.products.findAll({
     select: ['id', 'slug', 'updatedAt']
   })
@@ -176,10 +180,12 @@ export default defineEventHandler(async () => {
 })
 ```
 
-For large datasets, use caching and streaming:
+Switch to `defineCachedEventHandler()`{lang="ts"} when the query itself is expensive, or when several named sitemaps read this endpoint. Annotate the return value, because this handler has no sitemap-aware types:
 
 ```ts [server/api/products/all.ts]
-export default defineCachedEventHandler(async () => {
+import type { SitemapUrlInput } from '#sitemap/types'
+
+export default defineCachedEventHandler(async (): Promise<SitemapUrlInput[]> => {
   const products = []
   const cursor = db.products.cursor({
     select: ['slug', 'updatedAt']
@@ -198,6 +204,8 @@ export default defineCachedEventHandler(async () => {
   name: 'sitemap-products'
 })
 ```
+
+See [Which handler should I use?](/docs/sitemap/guides/dynamic-urls#which-handler-should-i-use) for the full rule.
 
 ## Debugging
 

--- a/docs/content/5.releases/7.v4.md
+++ b/docs/content/5.releases/7.v4.md
@@ -71,7 +71,7 @@ Learn more on the [Sitemap Caching](/docs/sitemap/advanced/performance) guide.
 
 ### Nitro Composables for better types
 
-When creating an API endpoint that returns URLs you should use the new [`defineSitemapEventHandler()`{lang="ts"}](/docs/sitemap/nitro-api/nitro-hooks) function for full TypeScript support.
+When creating an API endpoint that returns URLs you should use the new [`defineSitemapEventHandler()`{lang="ts"}](/docs/sitemap/guides/dynamic-urls#which-handler-should-i-use) function for full TypeScript support.
 
 ```ts
 // api/sitemap.ts


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Someone on Discord asked which handler to use for a sitemap source endpoint. Our docs answered three different ways:

- Dynamic URLs said use `defineSitemapEventHandler` and that caching is already handled
- Performance said use `defineCachedEventHandler` on any `/api/*` source, "without this, every fresh chunk re-hits your backend"
- Chunking used plain `defineEventHandler` in one example and `defineCachedEventHandler` in the next, with no explanation of the difference

The chunk claim was wrong. `getResolvedSitemapUrls` caches by base sitemap name, so all chunks of a sitemap share one entry.

One "Which handler should I use?" section in `dynamic-urls.md` now carries the rule, and the performance and chunking pages link to it. It says what `defineSitemapEventHandler` actually is, a typed alias for `defineEventHandler` with no caching, and when `defineCachedEventHandler` earns its place.

Docs only, no code change. #663 has a fix that would make the "several sitemaps read the same endpoint" case cheaper, and that wording can follow it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).