### PR TITLE
fix: fall back to default chunk size in auto-chunked sitemap index

### DIFF
--- a/src/runtime/server/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/server/sitemap/builder/sitemap-index.ts
@@ -94,7 +94,7 @@ async function buildSitemapIndexInternal(resolvers: NitroUrlResolvers, runtimeCo
     const sitemap = sitemaps.chunks
     const resolved = await getResolvedSitemapUrls(sitemap, 'sitemap', true, resolvers, runtimeConfig, nitro)
     allFailedSources.push(...resolved.failedSources)
-    const chunkCount = Math.ceil(resolved.urls.length / (defaultSitemapsChunkSize as number))
+    const chunkCount = Math.ceil(resolved.urls.length / (defaultSitemapsChunkSize || 1000))
     for (let i = 0; i < chunkCount; i++)
       pushEntry(String(i))
   }

--- a/test/unit/sitemap-index-chunk-size.test.ts
+++ b/test/unit/sitemap-index-chunk-size.test.ts
@@ -1,0 +1,85 @@
+import type { ModuleRuntimeConfig, NitroUrlResolvers } from '../../src/runtime/types'
+import { describe, expect, it, vi } from 'vitest'
+import { buildSitemapIndex } from '../../src/runtime/server/sitemap/builder/sitemap-index'
+import { sliceUrlsForChunk } from '../../src/runtime/server/sitemap/utils/chunk'
+
+const { urls } = vi.hoisted(() => ({
+  urls: Array.from({ length: 2500 }, (_, i) => ({ loc: `/page/${i}` })),
+}))
+
+vi.mock('#nuxtseo/h3', () => ({
+  getHeader: vi.fn(),
+}))
+vi.mock('#nuxtseo/nitro', () => ({
+  defineCachedFunction: (fn: unknown) => fn,
+}))
+vi.mock('#sitemap-virtual/static-config.mjs', () => ({
+  default: { cacheMaxAgeSeconds: 600 },
+}))
+vi.mock('../../src/runtime/server/sitemap/builder/sitemap', () => ({
+  getResolvedSitemapUrls: vi.fn(async () => ({ urls, failedSources: [] })),
+}))
+
+// An index for 2,500 URLs never needs this many entries. Past it the builder is looping
+// without bound, so throw and fail the test rather than hang the worker.
+const MAX_INDEX_ENTRIES = 10_000
+
+function createResolvers(): NitroUrlResolvers {
+  let emitted = 0
+  return {
+    // no event, so buildSitemapIndex skips the cached path
+    event: undefined as unknown as NitroUrlResolvers['event'],
+    // called once per index entry
+    canonicalUrlResolver: (path) => {
+      if (++emitted > MAX_INDEX_ENTRIES)
+        throw new Error(`runaway: sitemap index emitted more than ${MAX_INDEX_ENTRIES} entries for ${urls.length} URLs`)
+      return `https://example.com${path}`
+    },
+    relativeBaseUrlResolver: path => path,
+    fixSlashes: path => path,
+  }
+}
+
+// Mirrors the runtime config module.ts builds for `sitemaps: true`.
+function createRuntimeConfig(defaultSitemapsChunkSize: number | false) {
+  return {
+    sitemapsPathPrefix: '/__sitemap__/',
+    autoLastmod: false,
+    defaultSitemapsChunkSize,
+    sitemaps: {
+      index: { sitemapName: 'index', sitemaps: [] },
+      chunks: { sitemapName: 'chunks', includeAppSources: true },
+    },
+  } as unknown as ModuleRuntimeConfig
+}
+
+describe('sitemap index with automatic chunking', () => {
+  it('emits a finite index when defaultSitemapsChunkSize is false', async () => {
+    const { entries } = await buildSitemapIndex(createResolvers(), createRuntimeConfig(false))
+
+    expect(entries.map(entry => entry.sitemap)).toEqual([
+      'https://example.com/__sitemap__/0.xml',
+      'https://example.com/__sitemap__/1.xml',
+      'https://example.com/__sitemap__/2.xml',
+    ])
+  })
+
+  it('lists exactly the chunks the child sitemap handler serves', async () => {
+    const runtimeConfig = createRuntimeConfig(false)
+    const { entries } = await buildSitemapIndex(createResolvers(), runtimeConfig)
+
+    // buildSitemapUrls slices with `defaultSitemapsChunkSize || undefined`
+    const chunkLengths = entries.map(entry =>
+      sliceUrlsForChunk(urls, entry._sitemapName!, runtimeConfig.sitemaps, runtimeConfig.defaultSitemapsChunkSize || undefined).length,
+    )
+
+    expect(chunkLengths.every(length => length > 0)).toBe(true)
+    expect(chunkLengths.reduce((total, length) => total + length, 0)).toBe(urls.length)
+  })
+
+  it('uses a numeric defaultSitemapsChunkSize as the chunk size', async () => {
+    const { entries } = await buildSitemapIndex(createResolvers(), createRuntimeConfig(500))
+
+    expect(entries).toHaveLength(5)
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Bit of an edge-case but noticed this:

With `sitemaps: true` and `defaultSitemapsChunkSize: false`, `buildSitemapIndexInternal` computed the chunk count as `urls.length / false`. This is `Infinity` so the loop that adds index entries never ends, and the server stops responding until it runs out of memory.

Reproduction: https://github.com/rayblair06/sitemap-app

This PR introduces that if this happens then it falls back to the default `|| 1000`

~~No tests currently cover this edge case, but happy to add them :)~~

Edited:

Added test coverage.