### PR TITLE
fix(i18n): resolve sitemap URLs for each domain

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: ^5.3.14
       version: 5.3.14
     nuxtseo-shared:
-      specifier: ^5.3.15
-      version: 5.3.15
+      specifier: ^5.3.16
+      version: 5.3.16
     ofetch:
       specifier: ^1.5.1
       version: 1.5.1
@@ -149,7 +149,7 @@ importers:
         version: 4.2.3(2ad2906d2b0c8985281adebd4e4c5547)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: 5.3.15(301c423810fe1defc49de434267e903e)
+        version: 5.3.16(301c423810fe1defc49de434267e903e)
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1
@@ -5813,8 +5813,8 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@5.3.15:
-    resolution: {integrity: sha512-QAenIPP0lHAENPDpkAQzQ3++BMAzE1djOUyXx67KnMLjTFOOnNhFt9BPnRL/pIx0EgjbkuZYXOv8wh2mLUGcfQ==}
+  nuxtseo-shared@5.3.16:
+    resolution: {integrity: sha512-0Ood/aB/6PtWHFx6JB4Ub/InEbilW29cvTFGX5pIWyGf9Wewyil0T4481F/IUhvabHUGssWqErmn+mKoY/z6qA==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -9867,7 +9867,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config: 4.2.3(2ad2906d2b0c8985281adebd4e4c5547)
-      nuxtseo-shared: 5.3.15(301c423810fe1defc49de434267e903e)
+      nuxtseo-shared: 5.3.16(301c423810fe1defc49de434267e903e)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -14312,7 +14312,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config-kit: 4.2.3(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))
-      nuxtseo-shared: 5.3.15(301c423810fe1defc49de434267e903e)
+      nuxtseo-shared: 5.3.16(301c423810fe1defc49de434267e903e)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.2.3(vue@3.5.41(typescript@6.0.3))
@@ -14596,7 +14596,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@5.3.15(301c423810fe1defc49de434267e903e):
+  nuxtseo-shared@5.3.16(301c423810fe1defc49de434267e903e):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: ^5.3.14
       version: 5.3.14
     nuxtseo-shared:
-      specifier: ^5.3.14
-      version: 5.3.14
+      specifier: https://pkg.pr.new/nuxtseo-shared@ac9e521
+      version: 5.3.13
     ofetch:
       specifier: ^1.5.1
       version: 1.5.1
@@ -149,7 +149,7 @@ importers:
         version: 4.2.3(2ad2906d2b0c8985281adebd4e4c5547)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: 5.3.14(301c423810fe1defc49de434267e903e)
+        version: https://pkg.pr.new/nuxtseo-shared@ac9e521(301c423810fe1defc49de434267e903e)
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1
@@ -5801,6 +5801,21 @@ packages:
 
   nuxtseo-shared@5.3.14:
     resolution: {integrity: sha512-kt3IrUILAD4ElsA5+3uroQUHmDLfQkiYWrdXm4Eb/tSm7L0ug2WQc6Okh9m/KtypCVBfwtChrAVMgSyT/VYP5w==}
+    peerDependencies:
+      '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt-site-config: ^3.2.0 || ^4.0.0
+      vue: ^3.5.0
+      zod: ^3.23.0 || ^4.0.0
+    peerDependenciesMeta:
+      nuxt-site-config:
+        optional: true
+      zod:
+        optional: true
+
+  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@ac9e521:
+    resolution: {integrity: sha512-+FU4zlZJpxOYoBSOyC+DFpCp+GneTAUqUVM1QIot+5LmFKCxox2IUKW/7BUIFVl5yrKc+Pxwep7mHPKJH7k9Lg==, tarball: https://pkg.pr.new/nuxtseo-shared@ac9e521}
+    version: 5.3.13
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -14553,6 +14568,36 @@ snapshots:
       - zod
 
   nuxtseo-shared@5.3.14(301c423810fe1defc49de434267e903e):
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
+      '@nuxt/schema': 4.5.2
+      birpc: 4.2.0
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.146.0)(@types/node@26.2.0)(@vitejs/devtools-kit@0.4.10(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.41)(better-sqlite3@13.0.3)(cac@7.0.0)(db0@0.3.4(better-sqlite3@13.0.3))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))(yaml@2.9.0)
+      nypm: 0.6.9
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sirv: 3.0.2
+      std-env: 4.2.0
+      ufo: 1.6.4
+      vue: 3.5.41(typescript@6.0.3)
+    optionalDependencies:
+      nuxt-site-config: 4.2.3(2ad2906d2b0c8985281adebd4e4c5547)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+
+  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@ac9e521(301c423810fe1defc49de434267e903e):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: ^5.3.14
       version: 5.3.14
     nuxtseo-shared:
-      specifier: https://pkg.pr.new/nuxtseo-shared@d3e6504
-      version: 5.3.13
+      specifier: ^5.3.15
+      version: 5.3.15
     ofetch:
       specifier: ^1.5.1
       version: 1.5.1
@@ -149,7 +149,7 @@ importers:
         version: 4.2.3(2ad2906d2b0c8985281adebd4e4c5547)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: https://pkg.pr.new/nuxtseo-shared@d3e6504(301c423810fe1defc49de434267e903e)
+        version: 5.3.15(301c423810fe1defc49de434267e903e)
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1
@@ -5813,9 +5813,8 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@d3e6504:
-    resolution: {integrity: sha512-1cW3NmKf45KJlnnQuLoFKvv7r3ornj7x9LlSU7fI+fLOcTYFM85EXXfRdxYfk0sxtd9ZZM/GzqwXa4/K3bW8CA==, tarball: https://pkg.pr.new/nuxtseo-shared@d3e6504}
-    version: 5.3.13
+  nuxtseo-shared@5.3.15:
+    resolution: {integrity: sha512-QAenIPP0lHAENPDpkAQzQ3++BMAzE1djOUyXx67KnMLjTFOOnNhFt9BPnRL/pIx0EgjbkuZYXOv8wh2mLUGcfQ==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -9868,7 +9867,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config: 4.2.3(2ad2906d2b0c8985281adebd4e4c5547)
-      nuxtseo-shared: 5.3.14(301c423810fe1defc49de434267e903e)
+      nuxtseo-shared: 5.3.15(301c423810fe1defc49de434267e903e)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -14313,7 +14312,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config-kit: 4.2.3(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))
-      nuxtseo-shared: 5.3.14(301c423810fe1defc49de434267e903e)
+      nuxtseo-shared: 5.3.15(301c423810fe1defc49de434267e903e)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.2.3(vue@3.5.41(typescript@6.0.3))
@@ -14597,7 +14596,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@d3e6504(301c423810fe1defc49de434267e903e):
+  nuxtseo-shared@5.3.15(301c423810fe1defc49de434267e903e):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ catalogs:
       specifier: ^5.3.14
       version: 5.3.14
     nuxtseo-shared:
-      specifier: https://pkg.pr.new/nuxtseo-shared@ac9e521
+      specifier: https://pkg.pr.new/nuxtseo-shared@d3e6504
       version: 5.3.13
     ofetch:
       specifier: ^1.5.1
@@ -149,7 +149,7 @@ importers:
         version: 4.2.3(2ad2906d2b0c8985281adebd4e4c5547)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: https://pkg.pr.new/nuxtseo-shared@ac9e521(301c423810fe1defc49de434267e903e)
+        version: https://pkg.pr.new/nuxtseo-shared@d3e6504(301c423810fe1defc49de434267e903e)
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1
@@ -5813,8 +5813,8 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@ac9e521:
-    resolution: {integrity: sha512-+FU4zlZJpxOYoBSOyC+DFpCp+GneTAUqUVM1QIot+5LmFKCxox2IUKW/7BUIFVl5yrKc+Pxwep7mHPKJH7k9Lg==, tarball: https://pkg.pr.new/nuxtseo-shared@ac9e521}
+  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@d3e6504:
+    resolution: {integrity: sha512-1cW3NmKf45KJlnnQuLoFKvv7r3ornj7x9LlSU7fI+fLOcTYFM85EXXfRdxYfk0sxtd9ZZM/GzqwXa4/K3bW8CA==, tarball: https://pkg.pr.new/nuxtseo-shared@d3e6504}
     version: 5.3.13
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -14597,7 +14597,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@ac9e521(301c423810fe1defc49de434267e903e):
+  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@d3e6504(301c423810fe1defc49de434267e903e):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,7 @@ catalog:
   nuxt-i18n-micro: ^3.28.0
   nuxt-site-config: ^4.2.3
   nuxtseo-layer-devtools: ^5.3.14
-  nuxtseo-shared: ^5.3.15
+  nuxtseo-shared: ^5.3.16
   ofetch: ^1.5.1
   pathe: ^2.0.3
   pkg-types: ^2.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,7 @@ catalog:
   nuxt-i18n-micro: ^3.28.0
   nuxt-site-config: ^4.2.3
   nuxtseo-layer-devtools: ^5.3.14
-  nuxtseo-shared: https://pkg.pr.new/nuxtseo-shared@ac9e521
+  nuxtseo-shared: https://pkg.pr.new/nuxtseo-shared@d3e6504
   ofetch: ^1.5.1
   pathe: ^2.0.3
   pkg-types: ^2.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,7 @@ catalog:
   nuxt-i18n-micro: ^3.28.0
   nuxt-site-config: ^4.2.3
   nuxtseo-layer-devtools: ^5.3.14
-  nuxtseo-shared: https://pkg.pr.new/nuxtseo-shared@d3e6504
+  nuxtseo-shared: ^5.3.15
   ofetch: ^1.5.1
   pathe: ^2.0.3
   pkg-types: ^2.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,7 @@ catalog:
   nuxt-i18n-micro: ^3.28.0
   nuxt-site-config: ^4.2.3
   nuxtseo-layer-devtools: ^5.3.14
-  nuxtseo-shared: ^5.3.14
+  nuxtseo-shared: https://pkg.pr.new/nuxtseo-shared@ac9e521
   ofetch: ^1.5.1
   pathe: ^2.0.3
   pkg-types: ^2.3.1

--- a/src/module.ts
+++ b/src/module.ts
@@ -263,6 +263,23 @@ export default defineNuxtModule<ModuleOptions>({
           urls: [],
         }
         for (const pageLocales of Object.values(nuxtI18nConfig?.pages as Record<string, Record<string, string>>)) {
+          if (nuxtI18nConfig.multiDomainLocales && nuxtI18nConfig.strategy !== 'no_prefix') {
+            // A domain's default locale is only known when its sitemap is requested.
+            const sourceLocale = normalisedLocales.find(l => typeof pageLocales[l.code] === 'string' && !pageLocales[l.code]!.includes('['))
+            if (sourceLocale) {
+              i18nPagesSources.urls!.push({
+                loc: generatePathForI18nPages({
+                  localeCode: sourceLocale.code,
+                  pageLocales: pageLocales[sourceLocale.code]!,
+                  nuxtI18nConfig,
+                  normalisedLocales,
+                  forcedStrategy: 'prefix',
+                }),
+                _i18nTransform: true,
+              })
+            }
+            continue
+          }
           for (const localeCode in pageLocales) {
             const locale = normalisedLocales.find(l => l.code === localeCode)
             // add root entry for default locale and ignore dynamic routes
@@ -311,6 +328,7 @@ export default defineNuxtModule<ModuleOptions>({
       if (!hasSetAutoI18n && !hasDisabledAutoI18n && hasI18nConfigForAlternatives) {
         resolvedAutoI18n = {
           differentDomains: nuxtI18nConfig.differentDomains,
+          multiDomainLocales: nuxtI18nConfig.multiDomainLocales,
           defaultLocale: nuxtI18nConfig.defaultLocale!,
           locales: normalisedLocales,
           strategy: nuxtI18nConfig.strategy as 'prefix' | 'prefix_except_default' | 'prefix_and_default',

--- a/src/module.ts
+++ b/src/module.ts
@@ -980,6 +980,7 @@ export default defineNuxtModule<ModuleOptions>({
         strategy: nuxtI18nConfig.strategy || 'no_prefix',
         routesNameSeparator: nuxtI18nConfig.routesNameSeparator,
         normalisedLocales,
+        multiDomainLocales: nuxtI18nConfig.multiDomainLocales,
         filter: {
           include: serializeFilters(config.include || [], '@nuxtjs/sitemap') as (string | RegExp)[],
           exclude: serializeFilters(config.exclude || [], '@nuxtjs/sitemap') as (string | RegExp)[],

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -31,30 +31,43 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       }, baseURL || '/')
     : undefined
   const domainLocaleCodes = autoI18n?.multiDomainLocales && autoI18n.strategy !== 'no_prefix' ? new Set(autoI18n.locales.map(l => l.code)) : undefined
+  const requestHost = autoI18n?.multiDomainLocales && resolvers ? parseURL(resolvers.canonicalUrlResolver('/')).host?.toLowerCase() : undefined
+  const localeDomains = (locale: AutoI18nConfig['locales'][number]) => (locale.domains || (locale.domain ? [locale.domain] : []))
+    .map(domain => domain.replace(/^https?:\/\//i, '').toLowerCase())
+  const knownHost = requestHost && autoI18n && autoI18n.locales.some(locale => localeDomains(locale).includes(requestHost))
+  const availableLocales = autoI18n && autoI18n.locales.filter((locale) => {
+    const domains = localeDomains(locale)
+    return !autoI18n.multiDomainLocales || !knownHost || !domains.length || domains.includes(requestHost!)
+  })
   const domainLocaleKeys = autoI18n?.multiDomainLocales ? autoI18n.locales.map(l => l._sitemap) : []
   // 1. normalise
   const _urls: ResolvedSitemapUrl[] = []
+  const unavailableEntries = new Set<ResolvedSitemapUrl>()
   for (const _e of urls) {
     const e = preNormalizeEntry(_e, resolvers)
     if (autoI18n && domainLocaleCodes && !e._abs && !e._i18nTransform) {
       const prefix = splitForLocales(e._path?.pathname || '/', domainLocaleCodes)[0]
       const localeCode = prefix || autoI18n.defaultLocale
-      const sitemapLocale = typeof e._sitemap === 'string' ? resolveI18nSitemapLocaleKey(e._sitemap, domainLocaleKeys) : null
+      const sitemapLocale = isI18nMapped && typeof e._sitemap === 'string' ? resolveI18nSitemapLocaleKey(e._sitemap, domainLocaleKeys) : null
       const locale = autoI18n.locales.find(l => l.code === localeCode)
+      if (locale && availableLocales && !availableLocales.includes(locale))
+        continue
       // Nuxt emits every domain's default route. Keep only this domain's valid variant.
       if (autoI18n.strategy === 'prefix_except_default' && prefix === autoI18n.defaultLocale)
         continue
       if (sitemapLocale && sitemapLocale !== locale?._sitemap)
         continue
-      if (e.alternatives?.length) {
+      if (e._i18nGenerated && e.alternatives?.length) {
         const alternatives = e.alternatives.filter((alternative) => {
           if (alternative.hreflang === 'x-default')
             return false
           const alternateLocale = autoI18n.locales.find(l => l._hreflang === alternative.hreflang)
           if (!alternateLocale)
             return true
+          if (availableLocales && !availableLocales.includes(alternateLocale))
+            return false
           const alternatePrefix = splitForLocales(parseURL(alternative.href.toString()).pathname || '/', domainLocaleCodes)[0]
-          if (autoI18n.strategy === 'prefix_except_default' && alternatePrefix === autoI18n.defaultLocale)
+          if (['prefix_except_default', 'prefix_and_default'].includes(autoI18n.strategy) && alternatePrefix === autoI18n.defaultLocale)
             return false
           return (alternatePrefix || autoI18n.defaultLocale) === alternateLocale.code
         })
@@ -107,6 +120,8 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       if (!e._i18nTransform && !e.alternatives?.length) {
         const alternatives: AlternativeEntry[] = []
         for (const u of withoutPrefixPaths[e._pathWithoutPrefix] || []) {
+          if (autoI18n.multiDomainLocales && availableLocales && !availableLocales.includes(u._locale))
+            continue
           if (u._locale.code === defaultLocale) {
             alternatives.push({
               href: u.loc,
@@ -123,18 +138,38 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       }
       else if (e._i18nTransform) {
         delete e._i18nTransform
-        const routeEntries = resolveI18nRouteEntries(e._relativeLoc, autoI18n.multiDomainLocales
+        let routeEntries = resolveI18nRouteEntries(e._relativeLoc, autoI18n.multiDomainLocales
           ? {
               ...autoI18n,
               multiDomainLocales: false,
               locales: autoI18n.locales.map(({ domain: _, domains: __, defaultForDomains: ___, ...locale }) => locale),
             }
           : autoI18n, href => !filterPath || filterPath(href))
+        if (autoI18n.multiDomainLocales && availableLocales) {
+          const availableCodes = new Set(availableLocales.map(locale => locale.code))
+          const availableHreflangs = new Set(availableLocales.map(locale => locale._hreflang))
+          routeEntries = routeEntries.filter(entry => availableCodes.has(entry.locale.code)).map(entry => ({
+            ...entry,
+            alternatives: entry.alternatives.filter(alternative => alternative.hreflang === 'x-default' || availableHreflangs.has(alternative.hreflang)),
+          }))
+          if (!routeEntries.length) {
+            unavailableEntries.add(e)
+            continue
+          }
+          if (autoI18n.strategy === 'prefix_and_default') {
+            const defaultEntry = routeEntries.find(entry => entry.locale.code === defaultLocale)
+            if (defaultEntry) {
+              routeEntries.push({ ...defaultEntry, loc: `/${defaultLocale}${defaultEntry.loc === '/' ? '' : defaultEntry.loc}` })
+            }
+          }
+        }
         // keep single entry, just add alternatvies
         if (hasDifferentDomains) {
           e.alternatives = routeEntries[0]?.alternatives
         }
         else {
+          // A source locale may be unavailable on this domain. Replace its seed with a valid entry.
+          const sourceLocaleAvailable = routeEntries.some(entry => entry.locale.code === e._locale.code)
           // need to add urls for all other locales
           for (const { alternatives, locale: l, loc } of routeEntries) {
             const _sitemap = isI18nMapped ? l._sitemap : undefined
@@ -147,7 +182,7 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
               loc,
               alternatives,
             } as SitemapUrl, resolvers) as NormalizedI18n
-            if (e._locale.code === newEntry._locale.code) {
+            if (e._index !== undefined && (e._locale.code === newEntry._locale.code || !sourceLocaleAvailable)) {
               // replace
               _urls[e._index!] = newEntry
               // avoid getting re-replaced
@@ -167,5 +202,5 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
         _urls[e._index] = e
     }
   }
-  return _urls
+  return unavailableEntries.size ? _urls.filter(entry => !unavailableEntries.has(entry)) : _urls
 }

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -57,8 +57,10 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
         continue
       if (sitemapLocale && sitemapLocale !== locale?._sitemap)
         continue
-      if (e._i18nGenerated && e.alternatives?.length) {
+      if (e.alternatives?.some(alternative => alternative._i18nGenerated === alternative.href.toString())) {
         const alternatives = e.alternatives.filter((alternative) => {
+          if (alternative._i18nGenerated !== alternative.href.toString())
+            return true
           if (alternative.hreflang === 'x-default')
             return false
           const alternateLocale = autoI18n.locales.find(l => l._hreflang === alternative.hreflang)
@@ -73,7 +75,9 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
         })
         const defaultHreflang = autoI18n.locales.find(l => l.code === autoI18n.defaultLocale)?._hreflang
         const defaultAlternative = alternatives.find(a => a.hreflang === defaultHreflang)
-        e.alternatives = defaultAlternative ? [...alternatives, { ...defaultAlternative, hreflang: 'x-default' }] : alternatives
+        e.alternatives = defaultAlternative && !alternatives.some(alternative => alternative.hreflang === 'x-default')
+          ? [...alternatives, { ...defaultAlternative, hreflang: 'x-default' }]
+          : alternatives
       }
     }
     if (e.loc && (!filterPath || filterPath(e.loc, e._path?.pathname)))

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -8,7 +8,8 @@ import type {
   SitemapUrl,
   SitemapUrlInput,
 } from '../../../types'
-import { createPathFilter, resolveI18nRouteEntries, splitForLocales } from '../../../utils-pure'
+import { parseURL } from 'ufo'
+import { createPathFilter, resolveI18nRouteEntries, resolveI18nSitemapLocaleKey, splitForLocales } from '../../../utils-pure'
 import { preNormalizeEntry } from '../urlset/normalise'
 
 export interface NormalizedI18n extends ResolvedSitemapUrl {
@@ -29,10 +30,39 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
         exclude: sitemap.exclude,
       }, baseURL || '/')
     : undefined
+  const domainLocaleCodes = autoI18n?.multiDomainLocales && autoI18n.strategy !== 'no_prefix' ? new Set(autoI18n.locales.map(l => l.code)) : undefined
+  const domainLocaleKeys = autoI18n?.multiDomainLocales ? autoI18n.locales.map(l => l._sitemap) : []
   // 1. normalise
   const _urls: ResolvedSitemapUrl[] = []
   for (const _e of urls) {
     const e = preNormalizeEntry(_e, resolvers)
+    if (autoI18n && domainLocaleCodes && !e._abs && !e._i18nTransform) {
+      const prefix = splitForLocales(e._path?.pathname || '/', domainLocaleCodes)[0]
+      const localeCode = prefix || autoI18n.defaultLocale
+      const sitemapLocale = typeof e._sitemap === 'string' ? resolveI18nSitemapLocaleKey(e._sitemap, domainLocaleKeys) : null
+      const locale = autoI18n.locales.find(l => l.code === localeCode)
+      // Nuxt emits every domain's default route. Keep only this domain's valid variant.
+      if (autoI18n.strategy === 'prefix_except_default' && prefix === autoI18n.defaultLocale)
+        continue
+      if (sitemapLocale && sitemapLocale !== locale?._sitemap)
+        continue
+      if (e.alternatives?.length) {
+        const alternatives = e.alternatives.filter((alternative) => {
+          if (alternative.hreflang === 'x-default')
+            return false
+          const alternateLocale = autoI18n.locales.find(l => l._hreflang === alternative.hreflang)
+          if (!alternateLocale)
+            return true
+          const alternatePrefix = splitForLocales(parseURL(alternative.href.toString()).pathname || '/', domainLocaleCodes)[0]
+          if (autoI18n.strategy === 'prefix_except_default' && alternatePrefix === autoI18n.defaultLocale)
+            return false
+          return (alternatePrefix || autoI18n.defaultLocale) === alternateLocale.code
+        })
+        const defaultHreflang = autoI18n.locales.find(l => l.code === autoI18n.defaultLocale)?._hreflang
+        const defaultAlternative = alternatives.find(a => a.hreflang === defaultHreflang)
+        e.alternatives = defaultAlternative ? [...alternatives, { ...defaultAlternative, hreflang: 'x-default' }] : alternatives
+      }
+    }
     if (e.loc && (!filterPath || filterPath(e.loc, e._path?.pathname)))
       _urls.push(e)
   }
@@ -93,7 +123,13 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       }
       else if (e._i18nTransform) {
         delete e._i18nTransform
-        const routeEntries = resolveI18nRouteEntries(e._relativeLoc, autoI18n, href => !filterPath || filterPath(href))
+        const routeEntries = resolveI18nRouteEntries(e._relativeLoc, autoI18n.multiDomainLocales
+          ? {
+              ...autoI18n,
+              multiDomainLocales: false,
+              locales: autoI18n.locales.map(({ domain: _, domains: __, defaultForDomains: ___, ...locale }) => locale),
+            }
+          : autoI18n, href => !filterPath || filterPath(href))
         // keep single entry, just add alternatvies
         if (hasDifferentDomains) {
           e.alternatives = routeEntries[0]?.alternatives

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -84,7 +84,9 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
           : alternatives
       }
     }
-    if (e.loc && (!filterPath || filterPath(e.loc, e._path?.pathname)))
+    // Transform seeds may use a prefix that no final URL keeps on this domain.
+    const needsExpansion = e._i18nTransform && !e._abs && autoI18n && autoI18n.strategy !== 'no_prefix'
+    if (e.loc && (needsExpansion || !filterPath || filterPath(e.loc, e._path?.pathname)))
       _urls.push(e)
   }
 
@@ -117,8 +119,8 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       e._index = i
       e._key = `${e._sitemap || ''}${e._path?.pathname || '/'}${e._path?.search || ''}`
       withoutPrefixPaths[pathWithoutPrefix] = withoutPrefixPaths[pathWithoutPrefix] || []
-      // need to make sure the locale doesn't already exist
-      if (!withoutPrefixPaths[pathWithoutPrefix].some(e => e._locale.code === locale.code))
+      // Only actual routes can supply inferred alternatives, never transformation seeds.
+      if (!e._i18nTransform && !withoutPrefixPaths[pathWithoutPrefix].some(e => e._locale.code === locale.code))
         withoutPrefixPaths[pathWithoutPrefix].push(e)
       validI18nUrlsForTransform.push(e)
     }
@@ -210,5 +212,5 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
         _urls[e._index] = e
     }
   }
-  return unavailableEntries.size ? _urls.filter(entry => !unavailableEntries.has(entry)) : _urls
+  return _urls.filter(entry => !unavailableEntries.has(entry) && (!filterPath || filterPath(entry.loc, entry._path?.pathname)))
 }

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -46,7 +46,7 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
   const unavailableEntries = new Set<ResolvedSitemapUrl>()
   for (const _e of urls) {
     const e = preNormalizeEntry(_e, resolvers)
-    if (autoI18n && domainLocaleCodes && !e._abs && !e._i18nTransform) {
+    if (autoI18n && domainLocaleCodes && !e._abs && !e._i18nTransform && !e._i18nUnlocalized) {
       const prefix = splitForLocales(e._path?.pathname || '/', domainLocaleCodes)[0]
       const localeCode = prefix || autoI18n.defaultLocale
       const sitemapLocale = isI18nMapped && typeof e._sitemap === 'string' ? resolveI18nSitemapLocaleKey(e._sitemap, domainLocaleKeys) : null
@@ -101,7 +101,7 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       const _e = _urls[i]!
       if (_e._abs)
         continue
-      const split = splitForLocales(_e._relativeLoc, localeCodes)
+      const split = _e._i18nUnlocalized ? [null, _e._relativeLoc] as const : splitForLocales(_e._relativeLoc, localeCodes)
       let localeCode = split[0]
       const pathWithoutPrefix = split[1]
       if (!localeCode)
@@ -117,7 +117,7 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       e._key = `${e._sitemap || ''}${e._path?.pathname || '/'}${e._path?.search || ''}`
       withoutPrefixPaths[pathWithoutPrefix] = withoutPrefixPaths[pathWithoutPrefix] || []
       // Only actual routes can supply inferred alternatives, never transformation seeds.
-      if (!e._i18nTransform && !withoutPrefixPaths[pathWithoutPrefix].some(e => e._locale.code === locale.code))
+      if (!e._i18nTransform && !e._i18nUnlocalized && !withoutPrefixPaths[pathWithoutPrefix].some(e => e._locale.code === locale.code))
         withoutPrefixPaths[pathWithoutPrefix].push(e)
       validI18nUrlsForTransform.push(e)
     }
@@ -126,7 +126,7 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       // let's try and find other urls that we can use for alternatives
       if (!e._i18nTransform && !e.alternatives?.length) {
         const alternatives: AlternativeEntry[] = []
-        for (const u of withoutPrefixPaths[e._pathWithoutPrefix] || []) {
+        for (const u of e._i18nUnlocalized ? [e] : withoutPrefixPaths[e._pathWithoutPrefix] || []) {
           if (autoI18n.multiDomainLocales && availableLocales && !availableLocales.includes(u._locale))
             continue
           if (u._locale.code === defaultLocale) {

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -37,11 +37,11 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
   const domainLocaleCodes = autoI18n?.multiDomainLocales && autoI18n.strategy !== 'no_prefix' ? new Set(autoI18n.locales.map(l => l.code)) : undefined
   const requestHost = autoI18n?.multiDomainLocales && resolvers ? parseURL(resolvers.canonicalUrlResolver('/')).host?.toLowerCase() : undefined
   const localeDomains = (locale: AutoI18nConfig['locales'][number]) => (locale.domains || (locale.domain ? [locale.domain] : []))
-    .map(domain => domain.replace(/^https?:\/\//i, '').toLowerCase())
+    .map(domain => parseURL(domain.includes('://') ? domain : `https://${domain}`).host?.toLowerCase())
   const knownHost = requestHost && autoI18n && autoI18n.locales.some(locale => localeDomains(locale).includes(requestHost))
   const availableLocales = autoI18n && autoI18n.locales.filter((locale) => {
     const domains = localeDomains(locale)
-    return !autoI18n.multiDomainLocales || !knownHost || !domains.length || domains.includes(requestHost!)
+    return !autoI18n.multiDomainLocales || !knownHost || domains.includes(requestHost!)
   })
   const domainLocaleKeys = autoI18n?.multiDomainLocales ? autoI18n.locales.map(l => l._sitemap) : []
   // 1. normalise

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -18,6 +18,10 @@ export interface NormalizedI18n extends ResolvedSitemapUrl {
   _index?: number
 }
 
+function isGeneratedAlternative(alternative: AlternativeEntry): boolean {
+  return alternative._i18nGenerated !== undefined && alternative._i18nGenerated === JSON.stringify([alternative.hreflang, alternative.href.toString()])
+}
+
 export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapUrlInput[], runtimeConfig: Pick<ModuleRuntimeConfig, 'autoI18n' | 'isI18nMapped'>, resolvers?: NitroUrlResolvers, baseURL?: string): ResolvedSitemapUrl[] {
   const {
     autoI18n,
@@ -57,9 +61,9 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
         continue
       if (sitemapLocale && sitemapLocale !== locale?._sitemap)
         continue
-      if (e.alternatives?.some(alternative => alternative._i18nGenerated === alternative.href.toString())) {
+      if (e.alternatives?.some(isGeneratedAlternative)) {
         const alternatives = e.alternatives.filter((alternative) => {
-          if (alternative._i18nGenerated !== alternative.href.toString())
+          if (!isGeneratedAlternative(alternative))
             return true
           if (alternative.hreflang === 'x-default')
             return false

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -41,7 +41,8 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
   const knownHost = requestHost && autoI18n && autoI18n.locales.some(locale => localeDomains(locale).includes(requestHost))
   const availableLocales = autoI18n && autoI18n.locales.filter((locale) => {
     const domains = localeDomains(locale)
-    return !autoI18n.multiDomainLocales || !knownHost || domains.includes(requestHost!)
+    // Nuxt serves locales without domain restrictions on every host.
+    return !autoI18n.multiDomainLocales || !knownHost || !domains.length || domains.includes(requestHost!)
   })
   const domainLocaleKeys = autoI18n?.multiDomainLocales ? autoI18n.locales.map(l => l._sitemap) : []
   // 1. normalise

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -8,6 +8,7 @@ import type {
   SitemapUrl,
   SitemapUrlInput,
 } from '../../../types'
+import { resolveI18nDomain } from 'nuxtseo-shared/i18n-runtime'
 import { parseURL } from 'ufo'
 import { createPathFilter, resolveI18nRouteEntries, resolveI18nSitemapLocaleKey, splitForLocales } from '../../../utils-pure'
 import { preNormalizeEntry } from '../urlset/normalise'
@@ -24,9 +25,13 @@ function isGeneratedAlternative(alternative: AlternativeEntry): boolean {
 
 export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapUrlInput[], runtimeConfig: Pick<ModuleRuntimeConfig, 'autoI18n' | 'isI18nMapped'>, resolvers?: NitroUrlResolvers, baseURL?: string): ResolvedSitemapUrl[] {
   const {
-    autoI18n,
+    autoI18n: configuredI18n,
     isI18nMapped,
   } = runtimeConfig
+  const requestHost = configuredI18n?.multiDomainLocales && resolvers ? parseURL(resolvers.canonicalUrlResolver('/')).host : undefined
+  const domain = configuredI18n?.multiDomainLocales ? resolveI18nDomain(requestHost, configuredI18n) : undefined
+  const autoI18n = configuredI18n && domain ? { ...configuredI18n, defaultLocale: domain.defaultLocale } : configuredI18n
+  const availableLocales = domain?.locales || autoI18n?.locales
   const hasFilters = !!sitemap.include?.length || !!sitemap.exclude?.length
   const filterPath = hasFilters
     ? createPathFilter({
@@ -35,15 +40,6 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       }, baseURL || '/')
     : undefined
   const domainLocaleCodes = autoI18n?.multiDomainLocales && autoI18n.strategy !== 'no_prefix' ? new Set(autoI18n.locales.map(l => l.code)) : undefined
-  const requestHost = autoI18n?.multiDomainLocales && resolvers ? parseURL(resolvers.canonicalUrlResolver('/')).host?.toLowerCase() : undefined
-  const localeDomains = (locale: AutoI18nConfig['locales'][number]) => (locale.domains || (locale.domain ? [locale.domain] : []))
-    .map(domain => parseURL(domain.includes('://') ? domain : `https://${domain}`).host?.toLowerCase())
-  const knownHost = requestHost && autoI18n && autoI18n.locales.some(locale => localeDomains(locale).includes(requestHost))
-  const availableLocales = autoI18n && autoI18n.locales.filter((locale) => {
-    const domains = localeDomains(locale)
-    // Nuxt serves locales without domain restrictions on every host.
-    return !autoI18n.multiDomainLocales || !knownHost || !domains.length || domains.includes(requestHost!)
-  })
   const domainLocaleKeys = autoI18n?.multiDomainLocales ? autoI18n.locales.map(l => l._sitemap) : []
   // 1. normalise
   const _urls: ResolvedSitemapUrl[] = []
@@ -149,20 +145,10 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       }
       else if (e._i18nTransform) {
         delete e._i18nTransform
-        let routeEntries = resolveI18nRouteEntries(e._relativeLoc, autoI18n.multiDomainLocales
-          ? {
-              ...autoI18n,
-              multiDomainLocales: false,
-              locales: autoI18n.locales.map(({ domain: _, domains: __, defaultForDomains: ___, ...locale }) => locale),
-            }
-          : autoI18n, href => !filterPath || filterPath(href))
-        if (autoI18n.multiDomainLocales && availableLocales) {
-          const availableCodes = new Set(availableLocales.map(locale => locale.code))
-          const availableHreflangs = new Set(availableLocales.map(locale => locale._hreflang))
-          routeEntries = routeEntries.filter(entry => availableCodes.has(entry.locale.code)).map(entry => ({
-            ...entry,
-            alternatives: entry.alternatives.filter(alternative => alternative.hreflang === 'x-default' || availableHreflangs.has(alternative.hreflang)),
-          }))
+        const routeEntries = resolveI18nRouteEntries(e._relativeLoc, autoI18n, href => !filterPath || filterPath(href), autoI18n.multiDomainLocales
+          ? { host: requestHost || '', domainMode: 'request' }
+          : {})
+        if (autoI18n.multiDomainLocales) {
           if (!routeEntries.length) {
             unavailableEntries.add(e)
             continue

--- a/src/runtime/server/sitemap/builder/entries.ts
+++ b/src/runtime/server/sitemap/builder/entries.ts
@@ -82,7 +82,9 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
       }
     }
     // Transform seeds may use a prefix that no final URL keeps on this domain.
-    const needsExpansion = e._i18nTransform && !e._abs && autoI18n && autoI18n.strategy !== 'no_prefix'
+    // A seed can also be absolute (multi-domain i18n bakes the source locale's
+    // domain into the loc), so expansion uses _relativeLoc and drops the origin.
+    const needsExpansion = e._i18nTransform && autoI18n && autoI18n.strategy !== 'no_prefix'
     if (e.loc && (needsExpansion || !filterPath || filterPath(e.loc, e._path?.pathname)))
       _urls.push(e)
   }
@@ -99,7 +101,7 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
     const validI18nUrlsForTransform: NormalizedI18n[] = []
     for (let i = 0; i < _urls.length; i++) {
       const _e = _urls[i]!
-      if (_e._abs)
+      if (_e._abs && !_e._i18nTransform)
         continue
       const split = _e._i18nUnlocalized ? [null, _e._relativeLoc] as const : splitForLocales(_e._relativeLoc, localeCodes)
       let localeCode = split[0]

--- a/src/runtime/server/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/server/sitemap/builder/sitemap-index.ts
@@ -5,7 +5,7 @@ import type {
   SitemapIndexEntry,
 } from '../../../types'
 import { joinURL } from 'ufo'
-import { getHeader } from '#nuxtseo/h3'
+import { getHeader, getRequestHost } from '#nuxtseo/h3'
 import { defineCachedFunction } from '#nuxtseo/nitro'
 // @ts-expect-error virtual module
 import staticConfig from '#sitemap-virtual/static-config.mjs'
@@ -28,7 +28,7 @@ const buildSitemapIndexCached = defineCachedFunction(
     base: 'sitemap', // Use the sitemap storage
     getKey: (event: H3Event) => {
       // Include headers that could affect the output in the cache key
-      const host = getHeader(event, 'x-forwarded-host') || getHeader(event, 'host') || ''
+      const host = getRequestHost(event, { xForwardedHost: true }) || ''
       const proto = getHeader(event, 'x-forwarded-proto') || 'https'
       return `sitemap-index-${proto}-${host}`
     },

--- a/src/runtime/server/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/server/sitemap/builder/sitemap-index.ts
@@ -28,7 +28,7 @@ const buildSitemapIndexCached = defineCachedFunction(
     base: 'sitemap', // Use the sitemap storage
     getKey: (event: H3Event) => {
       // Include headers that could affect the output in the cache key
-      const host = getHeader(event, 'host') || getHeader(event, 'x-forwarded-host') || ''
+      const host = getHeader(event, 'x-forwarded-host') || getHeader(event, 'host') || ''
       const proto = getHeader(event, 'x-forwarded-proto') || 'https'
       return `sitemap-index-${proto}-${host}`
     },

--- a/src/runtime/server/sitemap/builder/sitemap.ts
+++ b/src/runtime/server/sitemap/builder/sitemap.ts
@@ -38,11 +38,7 @@ export async function buildResolvedSitemapUrls(
   runtimeConfig: ModuleRuntimeConfig,
   nitro?: NitroApp,
 ): Promise<ResolvedSitemapUrlsResult> {
-  const { sitemaps, isI18nMapped, isMultiSitemap, sortEntries } = runtimeConfig
-  const requestDefaultLocale = resolvers.event?.context.nuxtI18n?.vueI18nOptions?.defaultLocale
-  const autoI18n = runtimeConfig.autoI18n?.multiDomainLocales && typeof requestDefaultLocale === 'string'
-    ? { ...runtimeConfig.autoI18n, defaultLocale: requestDefaultLocale }
-    : runtimeConfig.autoI18n
+  const { sitemaps, autoI18n, isI18nMapped, isMultiSitemap, sortEntries } = runtimeConfig
 
   let sourcesInput = effectiveSitemap.includeAppSources
     ? [...await globalSitemapSources(), ...await childSitemapSources(effectiveSitemap)]

--- a/src/runtime/server/sitemap/builder/sitemap.ts
+++ b/src/runtime/server/sitemap/builder/sitemap.ts
@@ -38,7 +38,11 @@ export async function buildResolvedSitemapUrls(
   runtimeConfig: ModuleRuntimeConfig,
   nitro?: NitroApp,
 ): Promise<ResolvedSitemapUrlsResult> {
-  const { sitemaps, autoI18n, isI18nMapped, isMultiSitemap, sortEntries } = runtimeConfig
+  const { sitemaps, isI18nMapped, isMultiSitemap, sortEntries } = runtimeConfig
+  const requestDefaultLocale = resolvers.event?.context.nuxtI18n?.vueI18nOptions?.defaultLocale
+  const autoI18n = runtimeConfig.autoI18n?.multiDomainLocales && typeof requestDefaultLocale === 'string'
+    ? { ...runtimeConfig.autoI18n, defaultLocale: requestDefaultLocale }
+    : runtimeConfig.autoI18n
 
   let sourcesInput = effectiveSitemap.includeAppSources
     ? [...await globalSitemapSources(), ...await childSitemapSources(effectiveSitemap)]
@@ -138,7 +142,7 @@ export const buildResolvedSitemapUrlsCached = defineCachedFunction(
     base: 'sitemap',
     maxAge: SERVER_CACHE_MAX_AGE,
     getKey: (event, _effectiveSitemap, matchName, isChunked) => {
-      const host = getHeader(event, 'host') || getHeader(event, 'x-forwarded-host') || ''
+      const host = getHeader(event, 'x-forwarded-host') || getHeader(event, 'host') || ''
       const proto = getHeader(event, 'x-forwarded-proto') || 'https'
       return `resolved-${isChunked ? 'chunked-' : ''}${matchName}-${proto}-${host}`
     },

--- a/src/runtime/server/sitemap/builder/xml.ts
+++ b/src/runtime/server/sitemap/builder/xml.ts
@@ -33,7 +33,7 @@ function buildUrlXml(url: ResolvedSitemapUrl, NL: string, I1: string, I2: string
     for (const alt of url.alternatives) {
       let attrs = ''
       for (const k in alt) {
-        if (Object.hasOwn(alt, k))
+        if ((k === 'href' || k === 'hreflang') && Object.hasOwn(alt, k))
           attrs += ` ${k}="${xmlEscape(String(alt[k as keyof typeof alt]))}"`
       }
       xml += `${I2}<xhtml:link rel="alternate"${attrs} />${NL}`

--- a/src/runtime/server/sitemap/nitro.ts
+++ b/src/runtime/server/sitemap/nitro.ts
@@ -266,7 +266,7 @@ async function buildSitemapXml(event: H3Event, definition: SitemapDefinition, re
 
 function getSitemapCacheKey(event: H3Event, definition: SitemapDefinition) {
   // Include headers that can affect absolute URL generation in the cache key.
-  const host = getHeader(event, 'host') || getHeader(event, 'x-forwarded-host') || ''
+  const host = getHeader(event, 'x-forwarded-host') || getHeader(event, 'host') || ''
   const proto = getHeader(event, 'x-forwarded-proto') || 'https'
   const sitemapName = definition.sitemapName || 'default'
   return `${sitemapName}-${proto}-${host}`

--- a/src/runtime/server/sitemap/urlset/normalise.ts
+++ b/src/runtime/server/sitemap/urlset/normalise.ts
@@ -162,7 +162,7 @@ export function normaliseEntry(_e: ResolvedSitemapUrl, defaults?: Omit<SitemapUr
 
   // correct alternative hrefs
   if (e.alternatives) {
-    const alternatives = e.alternatives.map(a => ({ ...a }))
+    const alternatives = e.alternatives.map(({ _i18nGenerated: _, ...alternative }) => alternative)
     for (const alt of alternatives) {
       if (typeof alt.href === 'string') {
         alt.href = resolve(alt.href, resolvers)

--- a/src/runtime/server/sitemap/urlset/sources.ts
+++ b/src/runtime/server/sitemap/urlset/sources.ts
@@ -160,7 +160,7 @@ const fetchSourceUrlsCached = defineCachedFunction(
     base: 'sitemap',
     maxAge: SERVER_CACHE_MAX_AGE,
     getKey: (event: H3Event, key: string) => {
-      const host = getHeader(event, 'host') || getHeader(event, 'x-forwarded-host') || ''
+      const host = getHeader(event, 'x-forwarded-host') || getHeader(event, 'host') || ''
       const proto = getHeader(event, 'x-forwarded-proto') || 'https'
       return `source-${proto}-${host}-${hashCacheKey(key)}`
     },

--- a/src/runtime/server/utils.ts
+++ b/src/runtime/server/utils.ts
@@ -82,7 +82,7 @@ const resolveSitemapSitemapsCached = defineCachedFunction(
     base: 'sitemap',
     // nitro calls getKey with the full fn args (event, nitro)
     getKey: (e?: H3Event) => {
-      const host = (e && (getHeader(e, 'host') || getHeader(e, 'x-forwarded-host'))) || ''
+      const host = (e && (getHeader(e, 'x-forwarded-host') || getHeader(e, 'host'))) || ''
       const proto = (e && getHeader(e, 'x-forwarded-proto')) || 'https'
       return `runtime-sitemaps-${proto}-${host}`
     },

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -447,6 +447,8 @@ export interface SitemapUrl {
   images?: Array<ImageEntry>
   videos?: Array<VideoEntry>
   _i18nTransform?: boolean
+  /** Alternatives generated from Nuxt routes need request-domain filtering. */
+  _i18nGenerated?: boolean
   /**
    * Route this URL to a specific sitemap. The name must exist in the sitemap config,
    * either set in `nuxt.config` or registered with the `sitemap:sitemaps-resolved` hook.

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -237,6 +237,7 @@ interface LocaleObject extends Record<string, any> {
 }
 
 export interface AutoI18nConfig {
+  multiDomainLocales?: boolean
   differentDomains?: boolean
   locales: (LocaleObject & { _sitemap: string, _hreflang: string })[]
   defaultLocale: string

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -447,6 +447,8 @@ export interface SitemapUrl {
   images?: Array<ImageEntry>
   videos?: Array<VideoEntry>
   _i18nTransform?: boolean
+  /** Nuxt left this route outside locale routing. */
+  _i18nUnlocalized?: true
   /**
    * Route this URL to a specific sitemap. The name must exist in the sitemap config,
    * either set in `nuxt.config` or registered with the `sitemap:sitemaps-resolved` hook.

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -447,8 +447,6 @@ export interface SitemapUrl {
   images?: Array<ImageEntry>
   videos?: Array<VideoEntry>
   _i18nTransform?: boolean
-  /** Alternatives generated from Nuxt routes need request-domain filtering. */
-  _i18nGenerated?: boolean
   /**
    * Route this URL to a specific sitemap. The name must exist in the sitemap config,
    * either set in `nuxt.config` or registered with the `sitemap:sitemaps-resolved` hook.
@@ -476,6 +474,8 @@ export type SitemapItemDefaults = Omit<SitemapUrl, 'loc'>
 export type SitemapStrict = Required<SitemapUrl>
 
 export interface AlternativeEntry {
+  /** Original generated href. Hook replacements and edits keep their explicit targets. */
+  _i18nGenerated?: string
   hreflang: string
   href: string | URL
 }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -474,7 +474,7 @@ export type SitemapItemDefaults = Omit<SitemapUrl, 'loc'>
 export type SitemapStrict = Required<SitemapUrl>
 
 export interface AlternativeEntry {
-  /** Original generated href. Hook replacements and edits keep their explicit targets. */
+  /** Original generated hreflang and href. Hook edits keep their explicit targets. */
   _i18nGenerated?: string
   hreflang: string
   href: string | URL

--- a/src/runtime/utils-pure.ts
+++ b/src/runtime/utils-pure.ts
@@ -1,4 +1,4 @@
-import type { LocaleAlternate, RuntimeI18nConfig } from 'nuxtseo-shared/i18n-runtime'
+import type { LocaleAlternate, RuntimeI18nConfig, RuntimeRouteContext } from 'nuxtseo-shared/i18n-runtime'
 import type { AlternativeEntry, AutoI18nConfig, FilterInput } from './types'
 import { createDefu } from 'defu'
 import { computeLocaleAlternates, resolveLocaleFromRoute } from 'nuxtseo-shared/i18n-runtime'
@@ -109,10 +109,10 @@ function localeAlternateHref(alternate: LocaleAlternate): string {
     : alternate.path
 }
 
-export function resolveI18nRouteEntries(route: string, i18n: AutoI18nConfig, includeHref: (href: string) => boolean = () => true): ResolvedI18nRouteEntry[] {
+export function resolveI18nRouteEntries(route: string, i18n: AutoI18nConfig, includeHref: (href: string) => boolean = () => true, context: RuntimeRouteContext = {}): ResolvedI18nRouteEntry[] {
   const runtimeConfig = toRuntimeI18nConfig(i18n)
-  const currentLocale = resolveLocaleFromRoute(route, runtimeConfig).locale
-  const alternates = computeLocaleAlternates(route, runtimeConfig, { locale: currentLocale })
+  const currentLocale = resolveLocaleFromRoute(route, runtimeConfig, context).locale
+  const alternates = computeLocaleAlternates(route, runtimeConfig, { ...context, locale: currentLocale })
   const localizedAlternates = alternates.map(alternate => ({
     alternate,
     href: localeAlternateHref(alternate),

--- a/src/utils-internal/nuxtSitemap.ts
+++ b/src/utils-internal/nuxtSitemap.ts
@@ -43,6 +43,7 @@ export interface NuxtPagesToSitemapEntriesOptions {
   isI18nMapped: boolean
   filter: { include?: FilterInput[], exclude?: FilterInput[] }
   autoI18n: boolean
+  multiDomainLocales?: boolean
 }
 
 interface PageEntry extends SitemapUrl {
@@ -117,7 +118,7 @@ export function convertNuxtPagesToSitemapEntries(pages: NuxtPage[], config: Nuxt
       return p
     })
 
-  if (config.strategy === 'prefix_and_default') {
+  if (config.strategy === 'prefix_and_default' && !config.multiDomainLocales) {
     // filter out any pages started with the default locale
     flattenedPages = flattenedPages.filter((p) => {
       if (p.page?.name) {
@@ -214,6 +215,7 @@ export function convertNuxtPagesToSitemapEntries(pages: NuxtPage[], config: Nuxt
       return {
         ...e,
         ...(alternatives.length ? { alternatives } : {}),
+        ...(config.multiDomainLocales && alternatives.length ? { _i18nGenerated: true } : {}),
       }
     })
   }).filter(Boolean).flat() as SitemapUrlInput[]

--- a/src/utils-internal/nuxtSitemap.ts
+++ b/src/utils-internal/nuxtSitemap.ts
@@ -173,7 +173,8 @@ export function convertNuxtPagesToSitemapEntries(pages: NuxtPage[], config: Nuxt
         if (localeGroups[name]?.some(a => a.locale === config.defaultLocale))
           return false
         const defaultLocale = config.normalisedLocales.find(l => l.code === config.defaultLocale)
-        if (defaultLocale && config.isI18nMapped)
+        // Nonlocalized pages use the request default on multi-domain sites.
+        if (defaultLocale && config.isI18nMapped && (!config.multiDomainLocales || config.strategy === 'no_prefix'))
           e._sitemap = defaultLocale._sitemap
         delete e.page
         delete e.locale
@@ -192,7 +193,7 @@ export function convertNuxtPagesToSitemapEntries(pages: NuxtPage[], config: Nuxt
               hreflang: locale?._hreflang,
               href,
             }
-          }).filter(Boolean)
+          }).filter(alternative => alternative !== false)
         : []
       if (config.autoI18n) {
         const xDefault = entries.find(a => a.locale === config.defaultLocale)

--- a/src/utils-internal/nuxtSitemap.ts
+++ b/src/utils-internal/nuxtSitemap.ts
@@ -214,8 +214,9 @@ export function convertNuxtPagesToSitemapEntries(pages: NuxtPage[], config: Nuxt
       delete e.locale
       return {
         ...e,
-        ...(alternatives.length ? { alternatives } : {}),
-        ...(config.multiDomainLocales && alternatives.length ? { _i18nGenerated: true } : {}),
+        ...(alternatives.length
+          ? { alternatives: config.multiDomainLocales ? alternatives.map(alternative => ({ ...alternative, _i18nGenerated: alternative.href })) : alternatives }
+          : {}),
       }
     })
   }).filter(Boolean).flat() as SitemapUrlInput[]

--- a/src/utils-internal/nuxtSitemap.ts
+++ b/src/utils-internal/nuxtSitemap.ts
@@ -215,7 +215,7 @@ export function convertNuxtPagesToSitemapEntries(pages: NuxtPage[], config: Nuxt
       return {
         ...e,
         ...(alternatives.length
-          ? { alternatives: config.multiDomainLocales ? alternatives.map(alternative => ({ ...alternative, _i18nGenerated: alternative.href })) : alternatives }
+          ? { alternatives: config.multiDomainLocales ? alternatives.map(alternative => ({ ...alternative, _i18nGenerated: JSON.stringify([alternative.hreflang, alternative.href]) })) : alternatives }
           : {}),
       }
     })

--- a/src/utils-internal/nuxtSitemap.ts
+++ b/src/utils-internal/nuxtSitemap.ts
@@ -172,6 +172,8 @@ export function convertNuxtPagesToSitemapEntries(pages: NuxtPage[], config: Nuxt
         // for example this will fix the `/` if the configuration is set to `prefix`
         if (localeGroups[name]?.some(a => a.locale === config.defaultLocale))
           return false
+        if (config.multiDomainLocales)
+          e._i18nUnlocalized = true
         const defaultLocale = config.normalisedLocales.find(l => l.code === config.defaultLocale)
         // Nonlocalized pages use the request default on multi-domain sites.
         if (defaultLocale && config.isI18nMapped && (!config.multiDomainLocales || config.strategy === 'no_prefix'))

--- a/test/e2e/i18n/multi-domain-custom-paths.test.ts
+++ b/test/e2e/i18n/multi-domain-custom-paths.test.ts
@@ -1,0 +1,62 @@
+import { get } from 'node:http'
+import { createResolver } from '@nuxt/kit'
+import { setup, url } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+const locales = ['en', 'de', 'it'] as const
+const aboutPaths = { en: '/about', de: '/ueber', it: '/informazioni' }
+const domains = ['english-brand.com', 'german-brand.de', 'italian-brand.it']
+
+await setup({
+  rootDir: resolve('../../fixtures/i18n-multi-domain'),
+  dev: false,
+  nuxtConfig: {
+    i18n: {
+      defaultLocale: 'en',
+      customRoutes: 'config',
+      pages: {
+        index: { en: '/', de: '/', it: '/' },
+        about: { en: '/about', de: '/ueber', it: '/informazioni' },
+      },
+    },
+  },
+})
+
+describe('multi domain locales', () => {
+  it.each(domains)('uses the default locale for %s without sharing cached URLs', async (host) => {
+    const defaultLocale = locales[domains.indexOf(host)]
+    for (const locale of locales) {
+      const xml = await new Promise<string>((resolve, reject) => {
+        get(url(`/__sitemap__/${locale}-pages.xml`), { headers: { host } }, (response) => {
+          let body = ''
+          response.setEncoding('utf8')
+          response.on('data', chunk => body += chunk)
+          response.on('end', () => resolve(body))
+          response.on('error', reject)
+        }).on('error', reject)
+      })
+      const paths = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(match => new URL(match[1]!).pathname)
+      const prefix = locale === defaultLocale ? '' : `/${locale}`
+      expect(paths.sort()).toEqual([prefix || '/', `${prefix}${aboutPaths[locale]}`, `${prefix}/extra`].sort())
+      for (const match of xml.matchAll(/<url>([\s\S]+?)<\/url>/g)) {
+        const loc = new URL(/<loc>([^<]+)<\/loc>/.exec(match[1]!)![1]!)
+        expect(loc.host).toBe(host)
+        const basePath = prefix ? loc.pathname.slice(prefix.length) || '/' : loc.pathname
+        const alternatives = [...match[1]!.matchAll(/<xhtml:link ([^>]+)\/>/g)].map((link) => {
+          const hreflang = /hreflang="([^"]+)"/.exec(link[1]!)![1]!
+          const href = /href="([^"]+)"/.exec(link[1]!)![1]!
+          return { hreflang, href }
+        })
+        const expected = [...locales, 'x-default'].map((hreflang) => {
+          const alternateLocale = hreflang === 'x-default' ? defaultLocale : hreflang
+          const alternatePrefix = alternateLocale === defaultLocale ? '' : `/${alternateLocale}`
+          const translatedPath = basePath === aboutPaths[locale] ? aboutPaths[alternateLocale as keyof typeof aboutPaths] : basePath
+          const path = alternatePrefix ? `${alternatePrefix}${translatedPath === '/' ? '' : translatedPath}` : translatedPath
+          return { hreflang, href: `https://${host}${path}` }
+        })
+        expect(alternatives.sort((a, b) => a.hreflang.localeCompare(b.hreflang))).toEqual(expected.sort((a, b) => a.hreflang.localeCompare(b.hreflang)))
+      }
+    }
+  })
+})

--- a/test/e2e/i18n/multi-domain-locales.test.ts
+++ b/test/e2e/i18n/multi-domain-locales.test.ts
@@ -47,4 +47,23 @@ describe('multi domain locales', () => {
       }
     }
   })
+
+  it('serves each forwarded domain its own sitemap index behind a rewriting proxy', async () => {
+    const fetchIndex = (host: string) => new Promise<string>((resolve, reject) => {
+      get(url('/sitemap_index.xml'), { headers: { 'host': 'proxy.internal', 'x-forwarded-host': host } }, (response) => {
+        let body = ''
+        response.setEncoding('utf8')
+        response.on('data', chunk => body += chunk)
+        response.on('end', () => resolve(body))
+        response.on('error', reject)
+      }).on('error', reject)
+    })
+    const indexes = { 'english-brand.com': await fetchIndex('english-brand.com'), 'german-brand.de': await fetchIndex('german-brand.de') }
+    for (const [host, xml] of Object.entries(indexes)) {
+      const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(match => new URL(match[1]!))
+      expect(locs.length).toBeGreaterThan(0)
+      for (const loc of locs)
+        expect(loc.host).toBe(host)
+    }
+  })
 })

--- a/test/e2e/i18n/multi-domain-locales.test.ts
+++ b/test/e2e/i18n/multi-domain-locales.test.ts
@@ -66,4 +66,40 @@ describe('multi domain locales', () => {
         expect(loc.host).toBe(host)
     }
   })
+
+  it('resolves each forwarded domain its own runtime-registered sitemaps behind a rewriting proxy', async () => {
+    const fetchIndex = (host: string) => new Promise<string>((resolve, reject) => {
+      get(url('/sitemap_index.xml'), { headers: { 'host': 'proxy.internal', 'x-forwarded-host': host } }, (response) => {
+        let body = ''
+        response.setEncoding('utf8')
+        response.on('data', chunk => body += chunk)
+        response.on('end', () => resolve(body))
+        response.on('error', reject)
+      }).on('error', reject)
+    })
+    const english = await fetchIndex('english-brand.com')
+    const german = await fetchIndex('german-brand.de')
+    expect(english).toContain('/__sitemap__/host-flag-english-brand.com.xml')
+    expect(english).not.toContain('/__sitemap__/host-flag-german-brand.de.xml')
+    expect(german).toContain('/__sitemap__/host-flag-german-brand.de.xml')
+    expect(german).not.toContain('/__sitemap__/host-flag-english-brand.com.xml')
+  })
+
+  it('serves each forwarded domain its own fetched source URLs behind a rewriting proxy', async () => {
+    const fetchSitemap = (host: string) => new Promise<string>((resolve, reject) => {
+      get(url('/__sitemap__/host-echo.xml'), { headers: { 'host': 'proxy.internal', 'x-forwarded-host': host } }, (response) => {
+        let body = ''
+        response.setEncoding('utf8')
+        response.on('data', chunk => body += chunk)
+        response.on('end', () => resolve(body))
+        response.on('error', reject)
+      }).on('error', reject)
+    })
+    const english = await fetchSitemap('english-brand.com')
+    const german = await fetchSitemap('german-brand.de')
+    expect(english).toContain('/echo-english-brand.com</loc>')
+    expect(english).not.toContain('/echo-german-brand.de')
+    expect(german).toContain('/echo-german-brand.de</loc>')
+    expect(german).not.toContain('/echo-english-brand.com')
+  })
 })

--- a/test/e2e/i18n/multi-domain-locales.test.ts
+++ b/test/e2e/i18n/multi-domain-locales.test.ts
@@ -1,0 +1,50 @@
+import { get } from 'node:http'
+import { createResolver } from '@nuxt/kit'
+import { setup, url } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+const locales = ['en', 'de', 'it']
+const domains = ['english-brand.com', 'german-brand.de', 'italian-brand.it']
+
+await setup({
+  rootDir: resolve('../../fixtures/i18n-multi-domain'),
+  dev: false,
+})
+
+describe('multi domain locales', () => {
+  it.each(domains.flatMap(host => [{ host, forwarded: false }, { host, forwarded: true }]))('uses $host with forwarded=$forwarded without sharing cached URLs', async ({ host, forwarded }) => {
+    const defaultLocale = locales[domains.indexOf(host)]
+    for (const locale of locales) {
+      const xml = await new Promise<string>((resolve, reject) => {
+        get(url(`/__sitemap__/${locale}-pages.xml`), { headers: forwarded ? { 'host': 'proxy.internal', 'x-forwarded-host': host } : { host } }, (response) => {
+          let body = ''
+          response.setEncoding('utf8')
+          response.on('data', chunk => body += chunk)
+          response.on('end', () => resolve(body))
+          response.on('error', reject)
+        }).on('error', reject)
+      })
+      const paths = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(match => new URL(match[1]!).pathname)
+      const prefix = locale === defaultLocale ? '' : `/${locale}`
+      expect(paths.sort()).toEqual([prefix || '/', `${prefix}/about`, `${prefix}/extra`].sort())
+      for (const match of xml.matchAll(/<url>([\s\S]+?)<\/url>/g)) {
+        const loc = new URL(/<loc>([^<]+)<\/loc>/.exec(match[1]!)![1]!)
+        expect(loc.host).toBe(host)
+        const basePath = prefix ? loc.pathname.slice(prefix.length) || '/' : loc.pathname
+        const alternatives = [...match[1]!.matchAll(/<xhtml:link ([^>]+)\/>/g)].map((link) => {
+          const hreflang = /hreflang="([^"]+)"/.exec(link[1]!)![1]!
+          const href = /href="([^"]+)"/.exec(link[1]!)![1]!
+          return { hreflang, href }
+        })
+        const expected = [...locales, 'x-default'].map((hreflang) => {
+          const alternateLocale = hreflang === 'x-default' ? defaultLocale : hreflang
+          const alternatePrefix = alternateLocale === defaultLocale ? '' : `/${alternateLocale}`
+          const path = alternatePrefix ? `${alternatePrefix}${basePath === '/' ? '' : basePath}` : basePath
+          return { hreflang, href: `https://${host}${path}` }
+        })
+        expect(alternatives.sort((a, b) => a.hreflang.localeCompare(b.hreflang))).toEqual(expected.sort((a, b) => a.hreflang.localeCompare(b.hreflang)))
+      }
+    }
+  })
+})

--- a/test/e2e/i18n/multi-domain-locales.test.ts
+++ b/test/e2e/i18n/multi-domain-locales.test.ts
@@ -27,7 +27,7 @@ describe('multi domain locales', () => {
       })
       const paths = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(match => new URL(match[1]!).pathname)
       const prefix = locale === defaultLocale ? '' : `/${locale}`
-      expect(paths.sort()).toEqual([prefix || '/', `${prefix}/about`, `${prefix}/extra`].sort())
+      expect(paths.sort()).toEqual([prefix || '/', `${prefix}/about`, `${prefix}/extra`, ...(locale === defaultLocale ? ['/privacy'] : [])].sort())
       for (const match of xml.matchAll(/<url>([\s\S]+?)<\/url>/g)) {
         const loc = new URL(/<loc>([^<]+)<\/loc>/.exec(match[1]!)![1]!)
         expect(loc.host).toBe(host)
@@ -37,7 +37,7 @@ describe('multi domain locales', () => {
           const href = /href="([^"]+)"/.exec(link[1]!)![1]!
           return { hreflang, href }
         })
-        const expected = [...locales, 'x-default'].map((hreflang) => {
+        const expected = (basePath === '/privacy' ? [defaultLocale!, 'x-default'] : [...locales, 'x-default']).map((hreflang) => {
           const alternateLocale = hreflang === 'x-default' ? defaultLocale : hreflang
           const alternatePrefix = alternateLocale === defaultLocale ? '' : `/${alternateLocale}`
           const path = alternatePrefix ? `${alternatePrefix}${basePath === '/' ? '' : basePath}` : basePath

--- a/test/e2e/i18n/multi-domain-prefix-and-default.test.ts
+++ b/test/e2e/i18n/multi-domain-prefix-and-default.test.ts
@@ -1,0 +1,41 @@
+import { get } from 'node:http'
+import { createResolver } from '@nuxt/kit'
+import { setup, url } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/i18n-multi-domain'),
+  dev: false,
+  nuxtConfig: {
+    i18n: {
+      strategy: 'prefix_and_default',
+      defaultLocale: 'en',
+      customRoutes: 'config',
+      pages: {
+        index: { en: '/', de: '/', it: '/' },
+        about: { en: '/about', de: '/ueber', it: '/informazioni' },
+      },
+    },
+  },
+})
+
+describe('multi domain default page variants', () => {
+  it.each([
+    ['english-brand.com', 'en', '/about'],
+    ['german-brand.de', 'de', '/ueber'],
+  ])('keeps both default variants on %s', async (host, locale, path) => {
+    const xml = await new Promise<string>((resolve, reject) => {
+      get(url(`/__sitemap__/${locale}-pages.xml`), { headers: { host } }, (response) => {
+        let body = ''
+        response.setEncoding('utf8')
+        response.on('data', chunk => body += chunk)
+        response.on('end', () => resolve(body))
+        response.on('error', reject)
+      }).on('error', reject)
+    })
+    const paths = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(match => new URL(match[1]!).pathname)
+    expect(paths.sort()).toEqual(['/', `/${locale}`, path, `/${locale}${path}`, '/extra', `/${locale}/extra`].sort())
+  })
+})

--- a/test/e2e/i18n/review-domainless.test.ts
+++ b/test/e2e/i18n/review-domainless.test.ts
@@ -1,0 +1,25 @@
+import { get } from 'node:http'
+import { createResolver } from '@nuxt/kit'
+import { setup, url } from '@nuxt/test-utils'
+import { expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+await setup({ rootDir: resolve('../../fixtures/review-domainless'), dev: false })
+function request(path: string) {
+  return new Promise<{ status: number | undefined, body: string }>((resolve, reject) => {
+    get(url(path), { headers: { host: 'english-brand.com' } }, (response) => {
+      let body = ''
+      response.setEncoding('utf8')
+      response.on('data', chunk => body += chunk)
+      response.on('end', () => resolve({ status: response.statusCode, body }))
+      response.on('error', reject)
+    }).on('error', reject)
+  })
+}
+it('includes a reachable locale without configured domains', async () => {
+  const page = await request('/de/about')
+  expect(page.status).toBe(200)
+  const sitemap = await request('/__sitemap__/de-pages.xml')
+  expect(sitemap.status).toBe(200)
+  expect(sitemap.body).toContain('<loc>https://english-brand.com/de/about</loc>')
+})

--- a/test/e2e/i18n/unlocalized-prefix.test.ts
+++ b/test/e2e/i18n/unlocalized-prefix.test.ts
@@ -1,0 +1,33 @@
+import { get } from 'node:http'
+import { createResolver } from '@nuxt/kit'
+import { setup, url } from '@nuxt/test-utils'
+import { expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+await setup({ rootDir: resolve('../../fixtures/i18n-unlocalized'), dev: false })
+
+function request(path: string, host: string) {
+  return new Promise<{ status: number | undefined, body: string }>((resolve, reject) => {
+    get(url(path), { headers: { host } }, (response) => {
+      let body = ''
+      response.setEncoding('utf8')
+      response.on('data', chunk => body += chunk)
+      response.on('end', () => resolve({ status: response.statusCode, body }))
+      response.on('error', reject)
+    }).on('error', reject)
+  })
+}
+
+it.each([
+  ['english-brand.com', 'en'],
+  ['german-brand.de', 'de'],
+])('keeps a nonlocalized locale-like route on %s', async (host, locale) => {
+  expect((await request('/en/legal', host)).status).toBe(200)
+
+  const sitemap = await request(`/__sitemap__/${locale}-pages.xml`, host)
+
+  expect(sitemap.status).toBe(200)
+  expect(sitemap.body).toContain(`<loc>https://${host}/en/legal</loc>`)
+  expect(sitemap.body).not.toContain(`<loc>https://${host}/legal</loc>`)
+  expect(sitemap.body).not.toContain(`<loc>https://${host}/de/en/legal</loc>`)
+})

--- a/test/fixtures/i18n-multi-domain/nuxt.config.ts
+++ b/test/fixtures/i18n-multi-domain/nuxt.config.ts
@@ -1,0 +1,29 @@
+import NuxtSitemap from '../../../src/module'
+
+const domains = ['english-brand.com', 'german-brand.de', 'italian-brand.it']
+
+export default defineNuxtConfig({
+  modules: [NuxtSitemap, '@nuxtjs/i18n'],
+  compatibilityDate: '2024-07-22',
+  site: {
+    url: 'https://english-brand.com',
+    multiTenancy: domains.map(host => ({ hosts: [host], config: { url: `https://${host}` } })),
+  },
+  i18n: {
+    strategy: 'prefix_except_default',
+    multiDomainLocales: true,
+    detectBrowserLanguage: false,
+    locales: ['en', 'de', 'it'].map((code, i) => ({
+      code,
+      language: code,
+      domains,
+      defaultForDomains: [domains[i]!],
+    })),
+  },
+  sitemap: {
+    autoLastmod: false,
+    credits: false,
+    urls: [{ loc: '/extra', _i18nTransform: true }],
+    sitemaps: { pages: { includeAppSources: true } },
+  },
+})

--- a/test/fixtures/i18n-multi-domain/pages/about.vue
+++ b/test/fixtures/i18n-multi-domain/pages/about.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>About</div>
+</template>

--- a/test/fixtures/i18n-multi-domain/pages/index.vue
+++ b/test/fixtures/i18n-multi-domain/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Home</div>
+</template>

--- a/test/fixtures/i18n-multi-domain/pages/privacy.vue
+++ b/test/fixtures/i18n-multi-domain/pages/privacy.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineI18nRoute(false)
+</script>
+
+<template>
+  <div>Privacy</div>
+</template>

--- a/test/fixtures/i18n-multi-domain/server/api/__sitemap__/host-echo.get.ts
+++ b/test/fixtures/i18n-multi-domain/server/api/__sitemap__/host-echo.get.ts
@@ -1,0 +1,5 @@
+import { defineEventHandler, getRequestHost } from 'h3'
+
+export default defineEventHandler(event => ({
+  urls: [{ loc: `/echo-${getRequestHost(event, { xForwardedHost: true })}`, _sitemap: 'host-echo' }],
+}))

--- a/test/fixtures/i18n-multi-domain/server/plugins/host-sitemaps.ts
+++ b/test/fixtures/i18n-multi-domain/server/plugins/host-sitemaps.ts
@@ -1,0 +1,17 @@
+import { getHeader } from 'h3'
+import { defineNitroPlugin } from 'nitropack/runtime'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('sitemap:sitemaps-resolved', ({ sitemaps, event }) => {
+    const host = getHeader(event, 'x-forwarded-host') || getHeader(event, 'host') || ''
+    if (!host)
+      return
+    // a per-domain sitemap: only visible to the domain whose hook call registered it
+    const name = `host-flag-${host}`
+    if (!(name in sitemaps))
+      sitemaps[name] = { sitemapName: name, urls: [`/${name}`] }
+    // a shared definition whose source response depends on the request host
+    if (!('host-echo' in sitemaps))
+      sitemaps['host-echo'] = { sitemapName: 'host-echo', sources: ['/api/__sitemap__/host-echo'] }
+  })
+})

--- a/test/fixtures/i18n-unlocalized/nuxt.config.ts
+++ b/test/fixtures/i18n-unlocalized/nuxt.config.ts
@@ -1,0 +1,20 @@
+import NuxtSitemap from '../../../src/module'
+
+const hosts = ['english-brand.com', 'german-brand.de']
+
+export default defineNuxtConfig({
+  modules: [NuxtSitemap, '@nuxtjs/i18n'],
+  compatibilityDate: '2024-07-22',
+  site: {
+    url: `https://${hosts[0]}`,
+    multiTenancy: hosts.map(host => ({ hosts: [host], config: { url: `https://${host}` } })),
+  },
+  i18n: {
+    defaultLocale: 'en',
+    strategy: 'prefix_except_default',
+    multiDomainLocales: true,
+    detectBrowserLanguage: false,
+    locales: ['en', 'de'].map((code, i) => ({ code, domains: [hosts[i]!], defaultForDomains: [hosts[i]!] })),
+  },
+  sitemap: { sitemaps: { pages: { includeAppSources: true } } },
+})

--- a/test/fixtures/i18n-unlocalized/pages/en/legal.vue
+++ b/test/fixtures/i18n-unlocalized/pages/en/legal.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineI18nRoute(false)
+</script>
+
+<template>
+  <div>Legal</div>
+</template>

--- a/test/fixtures/nuxt5/package.json
+++ b/test/fixtures/nuxt5/package.json
@@ -10,6 +10,7 @@
     "@nuxtjs/sitemap": "file:./module.tgz",
     "nitro": "3.0.260610-beta",
     "nuxt-site-config": "^4.1.4",
+    "nuxtseo-shared": "https://pkg.pr.new/nuxtseo-shared@ac9e521",
     "nuxt": "npm:nuxt-nightly@5.0.0-29762711.192612c7",
     "vue": "^3.5.40",
     "vue-router": "^5.2.0"

--- a/test/fixtures/nuxt5/package.json
+++ b/test/fixtures/nuxt5/package.json
@@ -10,7 +10,6 @@
     "@nuxtjs/sitemap": "file:./module.tgz",
     "nitro": "3.0.260610-beta",
     "nuxt-site-config": "^4.1.4",
-    "nuxtseo-shared": "https://pkg.pr.new/nuxtseo-shared@d3e6504",
     "nuxt": "npm:nuxt-nightly@5.0.0-29762711.192612c7",
     "vue": "^3.5.40",
     "vue-router": "^5.2.0"

--- a/test/fixtures/nuxt5/package.json
+++ b/test/fixtures/nuxt5/package.json
@@ -10,7 +10,7 @@
     "@nuxtjs/sitemap": "file:./module.tgz",
     "nitro": "3.0.260610-beta",
     "nuxt-site-config": "^4.1.4",
-    "nuxtseo-shared": "https://pkg.pr.new/nuxtseo-shared@ac9e521",
+    "nuxtseo-shared": "https://pkg.pr.new/nuxtseo-shared@d3e6504",
     "nuxt": "npm:nuxt-nightly@5.0.0-29762711.192612c7",
     "vue": "^3.5.40",
     "vue-router": "^5.2.0"

--- a/test/fixtures/nuxt5/pnpm-lock.yaml
+++ b/test/fixtures/nuxt5/pnpm-lock.yaml
@@ -347,7 +347,7 @@ packages:
         optional: true
 
   '@nuxtjs/sitemap@file:module.tgz':
-    resolution: {integrity: sha512-We/ktZMnS88ya6Xj8jQL1oJ5zTiNde/cobC3olV6ti35JEdfQSbUP4CHRTrNEUKvhLAAlZNOgOvxMx68BZt5Bw==, tarball: file:module.tgz}
+    resolution: {integrity: sha512-5nw7l1tzYAQnz2mwip0p7zAMpVhyGBFFdYZfjDCpZ9vvGpKQj4w9Kfi3XxybDH7aUoGMmtM7NG29R5RIrGEy3w==, tarball: file:module.tgz}
     version: 8.5.0
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -1324,6 +1324,20 @@ packages:
 
   nuxtseo-shared@5.3.15:
     resolution: {integrity: sha512-QAenIPP0lHAENPDpkAQzQ3++BMAzE1djOUyXx67KnMLjTFOOnNhFt9BPnRL/pIx0EgjbkuZYXOv8wh2mLUGcfQ==}
+    peerDependencies:
+      '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt-site-config: ^3.2.0 || ^4.0.0
+      vue: ^3.5.0
+      zod: ^3.23.0 || ^4.0.0
+    peerDependenciesMeta:
+      nuxt-site-config:
+        optional: true
+      zod:
+        optional: true
+
+  nuxtseo-shared@5.3.16:
+    resolution: {integrity: sha512-0Ood/aB/6PtWHFx6JB4Ub/InEbilW29cvTFGX5pIWyGf9Wewyil0T4481F/IUhvabHUGssWqErmn+mKoY/z6qA==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -2630,7 +2644,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       nuxt-site-config: 4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.15(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.16(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -3663,7 +3677,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config-kit: 4.2.3(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vue@3.5.40(typescript@6.0.3))
-      nuxtseo-shared: 5.3.13(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.15(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.2.3(vue@3.5.40(typescript@6.0.3))
@@ -3710,7 +3724,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@5.3.13(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.3.15(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)
@@ -3740,7 +3754,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@5.3.15(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.3.16(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)

--- a/test/fixtures/nuxt5/pnpm-lock.yaml
+++ b/test/fixtures/nuxt5/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@nuxtjs/sitemap>nuxtseo-shared': '-'
-
 importers:
 
   .:
@@ -23,9 +20,6 @@ importers:
       nuxt-site-config:
         specifier: ^4.1.4
         version: 4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared:
-        specifier: https://pkg.pr.new/nuxtseo-shared@d3e6504
-        version: https://pkg.pr.new/nuxtseo-shared@d3e6504(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       vue:
         specifier: ^3.5.40
         version: 3.5.40(typescript@6.0.3)
@@ -353,7 +347,7 @@ packages:
         optional: true
 
   '@nuxtjs/sitemap@file:module.tgz':
-    resolution: {integrity: sha512-Tba3MkKzqLZgmSC5CjQnVd8B0KUlWXe00r0w8+RzE9AFA1hCCTrXA2MxSFG+EE0iqxBhZhB4y/3N8RbD3tOBag==, tarball: file:module.tgz}
+    resolution: {integrity: sha512-We/ktZMnS88ya6Xj8jQL1oJ5zTiNde/cobC3olV6ti35JEdfQSbUP4CHRTrNEUKvhLAAlZNOgOvxMx68BZt5Bw==, tarball: file:module.tgz}
     version: 8.5.0
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -1328,9 +1322,8 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@d3e6504:
-    resolution: {integrity: sha512-1cW3NmKf45KJlnnQuLoFKvv7r3ornj7x9LlSU7fI+fLOcTYFM85EXXfRdxYfk0sxtd9ZZM/GzqwXa4/K3bW8CA==, tarball: https://pkg.pr.new/nuxtseo-shared@d3e6504}
-    version: 5.3.13
+  nuxtseo-shared@5.3.15:
+    resolution: {integrity: sha512-QAenIPP0lHAENPDpkAQzQ3++BMAzE1djOUyXx67KnMLjTFOOnNhFt9BPnRL/pIx0EgjbkuZYXOv8wh2mLUGcfQ==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -2637,6 +2630,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       nuxt-site-config: 4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.15(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -3746,7 +3740,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@d3e6504(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.3.15(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)
@@ -3766,7 +3760,7 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.40(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - magic-string

--- a/test/fixtures/nuxt5/pnpm-lock.yaml
+++ b/test/fixtures/nuxt5/pnpm-lock.yaml
@@ -347,7 +347,7 @@ packages:
         optional: true
 
   '@nuxtjs/sitemap@file:module.tgz':
-    resolution: {integrity: sha512-5nw7l1tzYAQnz2mwip0p7zAMpVhyGBFFdYZfjDCpZ9vvGpKQj4w9Kfi3XxybDH7aUoGMmtM7NG29R5RIrGEy3w==, tarball: file:module.tgz}
+    resolution: {integrity: sha512-5sHXhqmm0aU/9vUbH1XjV6z8SbIaG36tARimSvmcw4rlPhYBQrw3Qr3Jn/M79lYCgBBAPD1pmepTP+ZCzLUZew==, tarball: file:module.tgz}
     version: 8.5.0
     engines: {node: '>=18.0.0'}
     peerDependencies:

--- a/test/fixtures/nuxt5/pnpm-lock.yaml
+++ b/test/fixtures/nuxt5/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@nuxtjs/sitemap>nuxtseo-shared': '-'
+
 importers:
 
   .:
@@ -20,6 +23,9 @@ importers:
       nuxt-site-config:
         specifier: ^4.1.4
         version: 4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared:
+        specifier: https://pkg.pr.new/nuxtseo-shared@ac9e521
+        version: https://pkg.pr.new/nuxtseo-shared@ac9e521(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       vue:
         specifier: ^3.5.40
         version: 3.5.40(typescript@6.0.3)
@@ -81,21 +87,6 @@ packages:
   '@babel/types@8.0.4':
     resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
     engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@bomb.sh/tab@0.0.21':
-    resolution: {integrity: sha512-L9tqUOFS9GFJu+EWaoN6EvNAFKHtROJ3VmKP0AKGN4AnR/JXZbNPC9TXJhrNdTJISiUN7ZU0uJCq64fvyUVSvg==}
-    hasBin: true
-    peerDependencies:
-      cac: ^6.7.14
-      citty: ^0.1.6 || ^0.2.0
-      commander: ^13.1.0 || ^14.0.0 || ^15.0.0
-    peerDependenciesMeta:
-      cac:
-        optional: true
-      citty:
-        optional: true
-      commander:
-        optional: true
 
   '@clack/core@1.4.3':
     resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
@@ -229,17 +220,20 @@ packages:
   '@nodable/entities@3.0.0':
     resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
-  '@nuxt/cli-nightly@4.0.0-20260802-153152-e80f9d0':
-    resolution: {integrity: sha512-1+JRZ20DMJ48b6oB598aQdMNqtjx/nX0VuFBm9v4xjX2VpKe+hCkbhl1gpnNSRLxDn1EYLvgowd5NO1m9codiA==}
+  '@nuxt/cli-nightly@4.0.0-20260907-104727-9e18028':
+    resolution: {integrity: sha512-wib2C60dTGY69HcCjVdoXJS3UxujWIAg53mrqX8TNVVEYX7NVlJCiAjCm03Oi9MG3Tgg+tbYhF2h5vysvifQhA==}
     engines: {node: ^22.19.0 || ^24.11.0 || >=26.0.0}
     hasBin: true
     peerDependencies:
-      '@nuxt/schema': ^4.5.1
-      jiti: ^2.7.0
-      oxc-parser: '>=0.142.0'
+      '@nuxt/docs': ^4.0.0
+      '@nuxt/schema': ^3.0.0 || ^4.0.0
+      jiti: ^2.3.0
+      oxc-parser: '>=0.56.3'
       rolldown: ^1.0.0-rc.16 || ^1.0.0
-      serve: ^14.2.6
+      serve: ^14.0.0
     peerDependenciesMeta:
+      '@nuxt/docs':
+        optional: true
       '@nuxt/schema':
         optional: true
       jiti:
@@ -295,6 +289,10 @@ packages:
 
   '@nuxt/kit@4.5.1':
     resolution: {integrity: sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==}
+    engines: {node: '>=18.12.0'}
+
+  '@nuxt/kit@4.5.2':
+    resolution: {integrity: sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==}
     engines: {node: '>=18.12.0'}
 
   '@nuxt/nitro-server-nightly@5.0.0-29762711.192612c7':
@@ -355,8 +353,8 @@ packages:
         optional: true
 
   '@nuxtjs/sitemap@file:module.tgz':
-    resolution: {integrity: sha512-N/k5+tRtV90P2lQ+15Wl2n+HHWtNggNeH67X6EQHSQKv8qbV3IYvgh6EVHWmzc6JkBg2XkF1ZGJC3aOB69TE9Q==, tarball: file:module.tgz}
-    version: 8.3.2
+    resolution: {integrity: sha512-+bXKoJS0Nw/6awuQPQ33Pa/Fi04ds9AiuRuHp+BrrgOiLmbhH6aY5ezU3JfWBu50Zfk1CypXwRwttTEJtARnfQ==, tarball: file:module.tgz}
+    version: 8.5.0
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: '>=3'
@@ -686,6 +684,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue-macros/common@3.1.4':
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
@@ -804,6 +807,10 @@ packages:
 
   clickable-path@0.0.1:
     resolution: {integrity: sha512-PkJJGbxFRoWoxyYImJPPyd/RW+aVe0HQVBPhbp2KUaYZdpVNcIopUcE9UmCNAwdbj9frP5SzundqaePJF4ZWrw==}
+    engines: {node: '>=22.1.0'}
+
+  clickable-path@0.1.1:
+    resolution: {integrity: sha512-ROn/mdV2pR8WFdpJjFDCSouLRg9myf95xacO1iy8G/AVO/x5y124pjF3EaoWrTBRWC3vh0DPqa/MhKyx3mMeKg==}
     engines: {node: '>=22.1.0'}
 
   compatx@0.2.0:
@@ -987,8 +994,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  fzf@0.5.2:
-    resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
+  fuzzysort@4.0.2:
+    resolution: {integrity: sha512-3c7yD6rK1EXIsqpcu1ZVzXJugODWNMzvUij6yTiziaAHrpNS8kzFOI9mJLE8pmG4K9JOaVgzQRgklfOEk8f4Tg==}
 
   generic-names@4.0.0:
     resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
@@ -1294,13 +1301,21 @@ packages:
   nuxt-site-config-kit@4.1.4:
     resolution: {integrity: sha512-Xi/+9lnEpM72S48GM7XiweL6Vq5f0ge4N8Br10Qd2SZzTrKxOqg56B1Ef7l6skEi4hDWeeu7A1e+xE7Li9nHYg==}
 
+  nuxt-site-config-kit@4.2.3:
+    resolution: {integrity: sha512-xAU061MrxDlv1CjHjP9+Qg3mAdKxQgO9sFzoy+LblKW+DDLRMGjaEIna/QUk0F0kWzhrf4dSpOVTW8OZv26xVg==}
+
   nuxt-site-config@4.1.4:
     resolution: {integrity: sha512-e4fkqMyGhPjOFgha4sMphmJMB9XiKb/iSUZhcizxNrQwsmTCFBfb7I3n10pCFU/EQ5gaQMb+uB0iNp9N52Lnzg==}
     peerDependencies:
       vue: ^3.5.30
 
-  nuxtseo-shared@5.3.7:
-    resolution: {integrity: sha512-rH1QdrFoPEhXPX3b7f0KULob+PE5o84dV1P1s3rXDUddgZBJxSUdoOKOJh0X/5ahEJcQeckPdDV+siRMg/7mPQ==}
+  nuxt-site-config@4.2.3:
+    resolution: {integrity: sha512-m0CK1Q43T3qtVHSBYeDHav/hp8t/ahhlJGzwdBOQM6WcxeZpF1wcJazoGQAJEFamX1xcRAtA0ZuvvEkwHSMG0w==}
+    peerDependencies:
+      vue: ^3.5.30
+
+  nuxtseo-shared@5.3.13:
+    resolution: {integrity: sha512-IWfDaNv9xmi/etW4Nmqmd/S1r5mJ9K7lj8LfsflIJrbNV+2mMg/JUNUpDZmBaL/x+8cvI7fYqgEztzpNC8Cjcg==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -1313,8 +1328,9 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@5.3.9:
-    resolution: {integrity: sha512-TFp6klJ+K1QJGjfWSP6812ELehdsE0CKPTbbpFT5hV18+GNT76RavnimgJ4xYJlaU8SIbPq9di40JBGORN6wRA==}
+  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@ac9e521:
+    resolution: {integrity: sha512-+FU4zlZJpxOYoBSOyC+DFpCp+GneTAUqUVM1QIot+5LmFKCxox2IUKW/7BUIFVl5yrKc+Pxwep7mHPKJH7k9Lg==, tarball: https://pkg.pr.new/nuxtseo-shared@ac9e521}
+    version: 5.3.13
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -1489,8 +1505,13 @@ packages:
     peerDependencies:
       vue: ^3.5.30
 
-  sitemapd@0.2.1:
-    resolution: {integrity: sha512-ei/QCl/cxTPEC8b/KtibUalvORO4q1ZIN8h22gq6DaSUuHO9jolYViHSojEDPll/AmH4CQnFDkKNuiyMOs83ig==}
+  site-config-stack@4.2.3:
+    resolution: {integrity: sha512-9kJn4YoJvJqbxbE5T1WYl7ibL4SYngcKQ3sP8SfJcgzqtawMMwuBuC2h/DuFSLqVE5ZyMqGtMONm/ax8nSHVrw==}
+    peerDependencies:
+      vue: ^3.5.30
+
+  sitemapd@0.2.2:
+    resolution: {integrity: sha512-XAuW9x2cI3B757A/h2sFYfye5kBUHM8Gr6Muzwtve1oYRCv3BntoKMcgNu+GNF/LKIvUD1fQpBTVUCoHlzMihg==}
     engines: {node: '>=18.0.0'}
 
   source-map-js@1.2.1:
@@ -1504,6 +1525,11 @@ packages:
 
   srvx@0.12.5:
     resolution: {integrity: sha512-IuvtDNQg5EIwv3c6dleyau7u8hCyGQ7D6+V/QM799Aud07z0wCUcurKLTRfyG33C8oUY+UWcVBFkfHMcbtmRLA==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  srvx@1.0.4:
+    resolution: {integrity: sha512-eZmYaxUfZSo7/8m8UdsHRJNmTLSCTPPom9d7a60vMmuVeZvwhbvflRR+00/CxTCjMOFa5+H8tgBeNDVZ+w7AAQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -1802,6 +1828,10 @@ packages:
     resolution: {integrity: sha512-w2Eo8LSIIoW7qxNBzT7/17k+bh8plXo7G3dHjEIDqPlnluhzaxr9JX8F28VSYEtDvc1/a3WBDih6xNUZseebXg==}
     engines: {node: '>=18.12.0'}
 
+  verkit@0.4.0:
+    resolution: {integrity: sha512-sXMwN6DMHeouPfCxkxWkKAmxphWKEenHYY5H1nIBzU3PmDsmJp6kBXJdshjVdpMZuWCmL9SH7KFRx29AylpP6g==}
+    engines: {node: '>=18.12.0'}
+
   vite-node@6.0.0:
     resolution: {integrity: sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2023,11 +2053,6 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.4
 
-  '@bomb.sh/tab@0.0.21(cac@7.0.0)(citty@0.2.2)':
-    optionalDependencies:
-      cac: 7.0.0
-      citty: 0.2.2
-
   '@clack/core@1.4.3':
     dependencies:
       fast-wrap-ansi: 0.2.2
@@ -2211,43 +2236,34 @@ snapshots:
 
   '@nodable/entities@3.0.0': {}
 
-  '@nuxt/cli-nightly@4.0.0-20260802-153152-e80f9d0(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)':
+  '@nuxt/cli-nightly@4.0.0-20260907-104727-9e18028(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)':
     dependencies:
-      '@bomb.sh/tab': 0.0.21(cac@7.0.0)(citty@0.2.2)
       '@clack/prompts': 1.7.0
       args-tokenizer: 0.3.0
-      citty: 0.2.2
-      clickable-path: 0.0.1
+      clickable-path: 0.1.1
       confbox: 0.2.4
       consola: 3.4.2
       defu: 6.1.7
       exsolve: 1.1.1
-      fzf: 0.5.2
+      fuzzysort: 4.0.2
       get-port-please: 3.2.0
-      nypm: 0.6.9
       obug: 2.1.4
-      ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       rc9: 3.0.1
       scule: 1.3.0
-      source-map-js: 1.2.1
-      srvx: 0.12.5
+      srvx: 1.0.4
       std-env: 4.2.0
       tinyclip: 1.0.1
       tinyexec: 1.3.0
-      ufo: 1.6.4
       uqr: 0.1.3
-      verkit: 0.3.1
+      verkit: 0.4.0
     optionalDependencies:
       '@nuxt/schema': '@nuxt/schema-nightly@5.0.0-29762711.192612c7'
       jiti: 2.7.0
       oxc-parser: 0.140.0
       rolldown: 1.2.1
-    transitivePeerDependencies:
-      - cac
-      - commander
 
   '@nuxt/devalue@2.0.2': {}
 
@@ -2406,6 +2422,36 @@ snapshots:
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
       untyped: 2.0.0
       verkit: 0.2.0
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
+  '@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))':
+    dependencies:
+      c12: 3.3.4(magicast@0.5.4)
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.2
+      exsolve: 1.1.1
+      ignore: 7.0.6
+      jiti: 2.7.0
+      klona: 2.0.6
+      mlly: 1.8.2
+      nostics: 1.2.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+      scule: 1.3.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      untyped: 2.0.0
+      verkit: 0.3.1
     transitivePeerDependencies:
       - magic-string
       - magicast
@@ -2587,16 +2633,15 @@ snapshots:
 
   '@nuxtjs/sitemap@file:module.tgz(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
       consola: 3.4.2
       defu: 6.1.7
-      nuxt-site-config: 4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.9(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
       radix3: 1.1.2
-      sitemapd: 0.2.1
+      sitemapd: 0.2.2
       ufo: 1.6.4
       ultrahtml: 1.7.0
     optionalDependencies:
@@ -2849,11 +2894,13 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@vue-macros/common@3.1.4(vue@3.5.40(typescript@6.0.3))':
     dependencies:
@@ -3013,6 +3060,8 @@ snapshots:
 
   clickable-path@0.0.1: {}
 
+  clickable-path@0.1.1: {}
+
   compatx@0.2.0: {}
 
   confbox@0.1.8: {}
@@ -3138,7 +3187,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fzf@0.5.2: {}
+  fuzzysort@4.0.2: {}
 
   generic-names@4.0.0:
     dependencies:
@@ -3408,7 +3457,7 @@ snapshots:
   nuxt-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.5(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(vite@8.2.0)
-      '@nuxt/cli': '@nuxt/cli-nightly@4.0.0-20260802-153152-e80f9d0(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)'
+      '@nuxt/cli': '@nuxt/cli-nightly@4.0.0-20260907-104727-9e18028(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)'
       '@nuxt/devtools': 4.0.0-alpha.9(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))
       '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762711.192612c7(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
       '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(cac@7.0.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(ofetch@2.0.0-alpha.3)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)'
@@ -3485,6 +3534,7 @@ snapshots:
       - '@modelcontextprotocol/sdk'
       - '@netlify/blobs'
       - '@netlify/runtime'
+      - '@nuxt/docs'
       - '@oxc-project/types'
       - '@pinia/colada'
       - '@planetscale/database'
@@ -3509,7 +3559,6 @@ snapshots:
       - bufferutil
       - bun-types-no-globals
       - cac
-      - commander
       - crossws
       - cssnano
       - db0
@@ -3573,6 +3622,20 @@ snapshots:
       - unplugin
       - vue
 
+  nuxt-site-config-kit@4.2.3(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vue@3.5.40(typescript@6.0.3)):
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      site-config-stack: 4.2.3(vue@3.5.40(typescript@6.0.3))
+      std-env: 4.2.0
+      ufo: 1.6.4
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vue
+
   nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
@@ -3581,7 +3644,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config-kit: 4.1.4(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vue@3.5.40(typescript@6.0.3))
-      nuxtseo-shared: 5.3.7(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.13(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.4(vue@3.5.40(typescript@6.0.3))
@@ -3598,11 +3661,36 @@ snapshots:
       - vite
       - zod
 
-  nuxtseo-shared@5.3.7(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      consola: 3.4.2
+      defu: 6.1.7
+      h3: 1.15.11
+      nuxt-site-config-kit: 4.2.3(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vue@3.5.40(typescript@6.0.3))
+      nuxtseo-shared: 5.3.13(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      site-config-stack: 4.2.3(vue@3.5.40(typescript@6.0.3))
+      ufo: 1.6.4
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@nuxt/schema'
+      - magic-string
+      - magicast
+      - nuxt
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+      - zod
+
+  nuxtseo-shared@5.3.13(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
       '@nuxt/schema': 4.5.1
       birpc: 4.0.0
       consola: 3.4.2
@@ -3628,11 +3716,41 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@5.3.9(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.3.13(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/schema': 4.5.1
+      birpc: 4.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt: nuxt-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
+      nypm: 0.6.9
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sirv: 3.0.2
+      std-env: 4.2.0
+      ufo: 1.6.4
+      vue: 3.5.40(typescript@6.0.3)
+    optionalDependencies:
+      nuxt-site-config: 4.2.3(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+
+  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@ac9e521(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
       '@nuxt/schema': 4.5.1
       birpc: 4.0.0
       consola: 3.4.2
@@ -3833,7 +3951,12 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.40(typescript@6.0.3)
 
-  sitemapd@0.2.1:
+  site-config-stack@4.2.3(vue@3.5.40(typescript@6.0.3)):
+    dependencies:
+      ufo: 1.6.4
+      vue: 3.5.40(typescript@6.0.3)
+
+  sitemapd@0.2.2:
     dependencies:
       fast-xml-parser: 5.10.1
 
@@ -3842,6 +3965,8 @@ snapshots:
   srvx@0.11.22: {}
 
   srvx@0.12.5: {}
+
+  srvx@1.0.4: {}
 
   std-env@4.2.0: {}
 
@@ -3996,6 +4121,8 @@ snapshots:
 
   verkit@0.3.1: {}
 
+  verkit@0.4.0: {}
+
   vite-node@6.0.0(@vitejs/devtools@0.4.10)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       cac: 7.0.0
@@ -4120,7 +4247,7 @@ snapshots:
 
   vue-tsc@3.3.9(typescript@6.0.3):
     dependencies:
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@6.0.3)
       '@vue/language-core': 3.3.9
       typescript: 6.0.3
 

--- a/test/fixtures/nuxt5/pnpm-lock.yaml
+++ b/test/fixtures/nuxt5/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       nuxtseo-shared:
-        specifier: https://pkg.pr.new/nuxtseo-shared@ac9e521
-        version: https://pkg.pr.new/nuxtseo-shared@ac9e521(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+        specifier: https://pkg.pr.new/nuxtseo-shared@d3e6504
+        version: https://pkg.pr.new/nuxtseo-shared@d3e6504(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       vue:
         specifier: ^3.5.40
         version: 3.5.40(typescript@6.0.3)
@@ -353,7 +353,7 @@ packages:
         optional: true
 
   '@nuxtjs/sitemap@file:module.tgz':
-    resolution: {integrity: sha512-+bXKoJS0Nw/6awuQPQ33Pa/Fi04ds9AiuRuHp+BrrgOiLmbhH6aY5ezU3JfWBu50Zfk1CypXwRwttTEJtARnfQ==, tarball: file:module.tgz}
+    resolution: {integrity: sha512-Tba3MkKzqLZgmSC5CjQnVd8B0KUlWXe00r0w8+RzE9AFA1hCCTrXA2MxSFG+EE0iqxBhZhB4y/3N8RbD3tOBag==, tarball: file:module.tgz}
     version: 8.5.0
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -1328,8 +1328,8 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@ac9e521:
-    resolution: {integrity: sha512-+FU4zlZJpxOYoBSOyC+DFpCp+GneTAUqUVM1QIot+5LmFKCxox2IUKW/7BUIFVl5yrKc+Pxwep7mHPKJH7k9Lg==, tarball: https://pkg.pr.new/nuxtseo-shared@ac9e521}
+  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@d3e6504:
+    resolution: {integrity: sha512-1cW3NmKf45KJlnnQuLoFKvv7r3ornj7x9LlSU7fI+fLOcTYFM85EXXfRdxYfk0sxtd9ZZM/GzqwXa4/K3bW8CA==, tarball: https://pkg.pr.new/nuxtseo-shared@d3e6504}
     version: 5.3.13
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -2142,7 +2142,7 @@ snapshots:
   '@dxup/nuxt@0.5.5(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(vite@8.2.0)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
       '@vue/compiler-dom': 3.5.40
       chokidar: 5.0.0
       knitwork: 1.3.0
@@ -2269,7 +2269,7 @@ snapshots:
 
   '@nuxt/devtools-kit@4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)':
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
       tinyexec: 1.3.0
       vite: 8.2.0(@vitejs/devtools@0.4.10)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -2281,7 +2281,7 @@ snapshots:
 
   '@nuxt/devtools-kit@4.0.0-alpha.9(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)':
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
       nostics: 1.2.0
       tinyexec: 1.3.0
       vite: 8.2.0(@vitejs/devtools@0.4.10)(jiti@2.7.0)(yaml@2.9.0)
@@ -2297,7 +2297,7 @@ snapshots:
       '@devframes/plugin-code-server': 0.7.16(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(vite@8.2.0)
       '@devframes/plugin-data-inspector': 0.7.16(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(vite@8.2.0)
       '@nuxt/devtools-kit': 4.0.0-alpha.9(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
       '@vitejs/devtools': 0.4.10(crossws@0.4.10(srvx@0.11.22))(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)
       '@vitejs/devtools-kit': 0.4.10(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3)(vite@8.2.0)
       '@vue/devtools-core': 8.2.1(vue@3.5.40(typescript@6.0.3))
@@ -2324,7 +2324,7 @@ snapshots:
       unstorage: 1.17.5(db0@0.3.4)
       verkit: 0.2.0
       vite: 8.2.0(@vitejs/devtools@0.4.10)(jiti@2.7.0)(yaml@2.9.0)
-      vite-plugin-inspect: 12.0.2(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0)))(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3)(vite@8.2.0)
+      vite-plugin-inspect: 12.0.2(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0)))(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3)(vite@8.2.0)
       vite-plugin-vue-tracer: 1.4.0(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))
       ws: 8.21.1
     transitivePeerDependencies:
@@ -3610,7 +3610,7 @@ snapshots:
 
   nuxt-site-config-kit@4.1.4(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vue@3.5.40(typescript@6.0.3)):
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
       site-config-stack: 4.1.4(vue@3.5.40(typescript@6.0.3))
       std-env: 4.2.0
       ufo: 1.6.4
@@ -3746,7 +3746,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@ac9e521(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@https://pkg.pr.new/nuxtseo-shared@d3e6504(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)
@@ -4158,7 +4158,7 @@ snapshots:
       typescript: 6.0.3
       vue-tsc: 3.3.9(typescript@6.0.3)
 
-  vite-plugin-inspect@12.0.2(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0)))(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3)(vite@8.2.0):
+  vite-plugin-inspect@12.0.2(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0)))(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3)(vite@8.2.0):
     dependencies:
       '@vitejs/devtools-kit': 0.4.10(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3)(vite@8.2.0)
       ansis: 4.3.1
@@ -4171,7 +4171,7 @@ snapshots:
       unplugin-utils: 0.3.2
       vite: 8.2.0(@vitejs/devtools@0.4.10)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - cac

--- a/test/fixtures/nuxt5/pnpm-workspace.yaml
+++ b/test/fixtures/nuxt5/pnpm-workspace.yaml
@@ -12,3 +12,8 @@ minimumReleaseAgeExclude:
   - nuxtseo-shared@5.3.9
   # nuxt-site-config@4.1.4 still resolves this transitive version.
   - nuxtseo-shared@5.3.7
+
+# Install the pinned shared preview directly until its stable release.
+# pnpm blocks URL dependencies declared by the packed Sitemap package.
+overrides:
+  '@nuxtjs/sitemap>nuxtseo-shared': '-'

--- a/test/fixtures/nuxt5/pnpm-workspace.yaml
+++ b/test/fixtures/nuxt5/pnpm-workspace.yaml
@@ -8,12 +8,4 @@ minimumReleaseAgeExclude:
   - nuxt-site-config@4.1.4
   - site-config-stack@4.1.4
   - sitemapd@0.2.1
-  - nuxtseo-shared@5.3.8
-  - nuxtseo-shared@5.3.9
-  # nuxt-site-config@4.1.4 still resolves this transitive version.
-  - nuxtseo-shared@5.3.7
-
-# Install the pinned shared preview directly until its stable release.
-# pnpm blocks URL dependencies declared by the packed Sitemap package.
-overrides:
-  '@nuxtjs/sitemap>nuxtseo-shared': '-'
+  - nuxtseo-shared@5.3.7 || 5.3.8 || 5.3.9 || 5.3.15

--- a/test/fixtures/nuxt5/pnpm-workspace.yaml
+++ b/test/fixtures/nuxt5/pnpm-workspace.yaml
@@ -8,4 +8,4 @@ minimumReleaseAgeExclude:
   - nuxt-site-config@4.1.4
   - site-config-stack@4.1.4
   - sitemapd@0.2.1
-  - nuxtseo-shared@5.3.7 || 5.3.8 || 5.3.9 || 5.3.15
+  - nuxtseo-shared@5.3.7 || 5.3.8 || 5.3.9 || 5.3.15 || 5.3.16

--- a/test/fixtures/review-domainless/nuxt.config.ts
+++ b/test/fixtures/review-domainless/nuxt.config.ts
@@ -1,0 +1,17 @@
+import NuxtSitemap from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [NuxtSitemap, '@nuxtjs/i18n'],
+  compatibilityDate: '2024-07-22',
+  site: { url: 'https://english-brand.com' },
+  i18n: {
+    strategy: 'prefix_except_default',
+    multiDomainLocales: true,
+    detectBrowserLanguage: false,
+    locales: [
+      { code: 'en', language: 'en', domains: ['english-brand.com'], defaultForDomains: ['english-brand.com'] },
+      { code: 'de', language: 'de', domains: [] },
+    ],
+  },
+  sitemap: { sitemaps: { pages: { includeAppSources: true } } },
+})

--- a/test/fixtures/review-domainless/pages/about.vue
+++ b/test/fixtures/review-domainless/pages/about.vue
@@ -1,0 +1,1 @@
+<template><div>About</div></template>

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -42,6 +42,26 @@ describe('request domain sitemap entries', () => {
     expect(entries[0]?.alternatives).toEqual(alternatives)
   })
 
+  it('preserves alternatives replaced by a sitemap input hook', () => {
+    const alternatives = [{ hreflang: 'de', href: 'https://german-brand.de/ueber' }, { hreflang: 'x-default', href: 'https://select-brand.com/' }]
+    const inputs = appRoutes(autoI18n).map(entry => typeof entry === 'string' ? { loc: entry, alternatives } : ({ ...entry, alternatives }))
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, inputs, { autoI18n, isI18nMapped: true }, resolvers)
+    for (const entry of entries)
+      expect(entry.alternatives).toEqual(alternatives)
+  })
+
+  it('preserves generated alternatives edited by a sitemap input hook', () => {
+    const inputs = appRoutes(autoI18n).map(entry => typeof entry === 'string'
+      ? entry
+      : ({
+          ...entry,
+          alternatives: entry.alternatives?.map(alternative => ({ ...alternative, href: alternative.hreflang === 'x-default' ? 'https://select-brand.com/' : alternative.href })),
+        }))
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, inputs, { autoI18n, isI18nMapped: true }, resolvers)
+    for (const entry of entries)
+      expect(entry.alternatives).toContainEqual(expect.objectContaining({ hreflang: 'x-default', href: 'https://select-brand.com/' }))
+  })
+
   it('keeps locale-like ordinary sitemap names', () => {
     const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [{ loc: '/de/about', _sitemap: 'en-news' }], { autoI18n, isI18nMapped: false }, resolvers)
     expect(entries.map(e => ({ loc: e.loc, sitemap: e._sitemap }))).toEqual([{ loc: 'https://english-brand.com/de/about', sitemap: 'en-news' }])

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -110,13 +110,13 @@ describe('request domain sitemap entries', () => {
   it.each([
     { domains: undefined },
     { domains: [] },
-  ])('excludes locales without assigned domains: $domains', ({ domains }) => {
+  ])('keeps locales without domain restrictions: $domains', ({ domains }) => {
     const config = { ...autoI18n, locales: autoI18n.locales.map(l => l.code === 'it' ? { ...l, domains } : l) }
     for (const inputs of [appRoutes(config), [{ loc: '/about', _i18nTransform: true }]]) {
       const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, inputs, { autoI18n: config, isI18nMapped: true }, resolvers)
-      expect(entries.map(e => e.loc).sort()).toEqual(['https://english-brand.com/about', 'https://english-brand.com/de/about'])
+      expect(entries.map(e => e.loc).sort()).toEqual(['https://english-brand.com/about', 'https://english-brand.com/de/about', 'https://english-brand.com/it/about'])
       for (const entry of entries)
-        expect(entry.alternatives?.map(a => a.hreflang).sort()).toEqual(['de', 'en', 'x-default'])
+        expect(entry.alternatives?.map(a => a.hreflang).sort()).toEqual(['de', 'en', 'it', 'x-default'])
     }
   })
 

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -68,6 +68,47 @@ describe('request domain sitemap entries', () => {
     expect(entries.map(entry => ({ loc: entry.loc, sitemap: entry._sitemap }))).toEqual([{ loc: `https://${host}/privacy`, sitemap: defaultLocale }])
   })
 
+  it.each(['en', 'de', 'it'])('keeps a nonlocalized locale-like path on the %s host', (defaultLocale) => {
+    const config = { ...autoI18n, locales: autoI18n.locales.map(locale => ({ ...locale, domains: locale.defaultForDomains })) }
+    const inputs = convertNuxtPagesToSitemapEntries([{ name: 'legal', path: '/en/legal' }], {
+      normalisedLocales: config.locales,
+      multiDomainLocales: true,
+      defaultLocale: 'en',
+      strategy: 'prefix_except_default',
+      autoI18n: true,
+      autoLastmod: false,
+      isI18nMapped: true,
+      filter: {},
+    })
+    const host = config.locales.find(locale => locale.code === defaultLocale)!.defaultForDomains![0]!
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, inputs, { autoI18n: config, isI18nMapped: true }, {
+      ...resolvers,
+      canonicalUrlResolver: path => new URL(path, `https://${host}`).href,
+    })
+    expect(entries.map(entry => ({ loc: entry.loc, sitemap: entry._sitemap })))
+      .toEqual([{ loc: `https://${host}/en/legal`, sitemap: defaultLocale }])
+    expect(entries[0]?.alternatives?.map(alternative => alternative.hreflang).sort()).toEqual([defaultLocale, 'x-default'].sort())
+  })
+
+  it('does not infer a translation from a nonlocalized locale-like path', () => {
+    const inputs = convertNuxtPagesToSitemapEntries([{ name: 'legal', path: '/en/legal' }], {
+      normalisedLocales: autoI18n.locales,
+      multiDomainLocales: true,
+      defaultLocale: 'en',
+      strategy: 'prefix_except_default',
+      autoI18n: true,
+      autoLastmod: false,
+      isI18nMapped: true,
+      filter: {},
+    })
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [...inputs, { loc: '/de/en/legal' }], { autoI18n, isI18nMapped: true }, resolvers)
+
+    expect(entries.find(entry => entry.loc.endsWith('/en/legal') && entry._sitemap === 'en')?.alternatives?.map(alternative => alternative.hreflang).sort())
+      .toEqual(['en', 'x-default'])
+    expect(entries.find(entry => entry._sitemap === 'de')?.alternatives?.map(alternative => alternative.hreflang))
+      .toEqual(['de'])
+  })
+
   it('preserves supplied remote alternatives and x-default', () => {
     const alternatives = [
       { hreflang: 'en', href: 'https://english-brand.com/about' },

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -124,6 +124,55 @@ describe('request domain sitemap entries', () => {
     expect(entries).toEqual([])
   })
 
+  it.each([
+    { defaultLocale: 'en', strategy: 'prefix_except_default', exclude: ['/en/**'], expected: ['/about', '/de/ueber'], languages: ['de', 'en', 'x-default'] },
+    { defaultLocale: 'en', strategy: 'prefix_except_default', include: ['/about', '/de/**'], expected: ['/about', '/de/ueber'], languages: ['de', 'en', 'x-default'] },
+    { defaultLocale: 'en', strategy: 'prefix_except_default', exclude: ['/de/**'], expected: ['/about'], languages: ['en', 'x-default'] },
+    { defaultLocale: 'de', strategy: 'prefix_except_default', exclude: ['/en/**'], expected: ['/ueber'], languages: ['de', 'x-default'] },
+    { defaultLocale: 'de', strategy: 'prefix_except_default', include: ['/ueber'], expected: ['/ueber'], languages: ['de', 'x-default'] },
+    { defaultLocale: 'en', strategy: 'prefix_and_default', exclude: ['/en/**'], expected: ['/about', '/de/ueber'], languages: ['de', 'en', 'x-default'] },
+    { defaultLocale: 'de', strategy: 'prefix_and_default', exclude: ['/de/**'], expected: ['/en/about', '/ueber'], languages: ['de', 'en', 'x-default'] },
+    { defaultLocale: 'en', strategy: 'prefix_and_default', include: ['/en/**'], expected: ['/en/about'], languages: [] },
+    { defaultLocale: 'de', strategy: 'prefix_and_default', include: ['/de/**'], expected: ['/de/ueber'], languages: [] },
+    { defaultLocale: 'en', strategy: 'prefix_except_default', exclude: ['/**'], expected: [], languages: [] },
+  ] as const)('filters expanded custom pages: $defaultLocale $strategy $include $exclude', ({ defaultLocale, strategy, expected, languages, ...filters }) => {
+    const config: AutoI18nConfig = {
+      ...autoI18n,
+      defaultLocale,
+      strategy,
+      locales: autoI18n.locales.filter(locale => locale.code !== 'it'),
+      pages: { about: { en: '/about', de: '/ueber' } },
+    }
+    const host = config.locales.find(locale => locale.code === defaultLocale)!.defaultForDomains![0]!
+    const entries = resolveSitemapEntries({
+      sitemapName: 'sitemap.xml',
+      ...('include' in filters ? { include: [...filters.include] } : { exclude: [...filters.exclude] }),
+    }, [{ loc: '/en/about', _i18nTransform: true }], { autoI18n: config, isI18nMapped: true }, {
+      ...resolvers,
+      canonicalUrlResolver: (path: string) => new URL(path, `https://${host}`).href,
+    })
+    expect(entries.map(entry => entry.loc).sort()).toEqual(expected.map(path => `https://${host}${path}`).sort())
+    for (const entry of entries) {
+      expect(entry.alternatives?.map(alternative => alternative.hreflang).sort()).toEqual([...languages].sort())
+      const translatedPaths = { en: '/about', de: '/ueber' }
+      expect(entry.alternatives?.map(alternative => alternative.href).sort()).toEqual(languages.map((language) => {
+        const locale = language === 'x-default' ? defaultLocale : language as 'en' | 'de'
+        return `${locale === defaultLocale ? '' : `/${locale}`}${translatedPaths[locale]}`
+      }).sort())
+    }
+  })
+
+  it('does not infer filtered alternatives from deferred custom page seeds', () => {
+    const config: AutoI18nConfig = { ...autoI18n, pages: { about: { en: '/about', de: '/ueber', it: false } } }
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml', exclude: ['/en/**'] }, [
+      '/de/about',
+      { loc: '/en/about', _i18nTransform: true },
+    ], { autoI18n: config, isI18nMapped: true }, resolvers)
+    expect(entries.map(entry => entry.loc)).toContain('https://english-brand.com/de/ueber')
+    for (const entry of entries)
+      expect(entry.alternatives?.map(alternative => alternative.href)).not.toContain('https://english-brand.com/en/about')
+  })
+
   it('keeps both generated default route variants', () => {
     const config: AutoI18nConfig = { ...autoI18n, strategy: 'prefix_and_default' }
     const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, appRoutes(config), { autoI18n: config, isI18nMapped: true }, resolvers)

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -32,6 +32,25 @@ function appRoutes(config: AutoI18nConfig) {
 }
 
 describe('request domain sitemap entries', () => {
+  it.each(['en', 'de', 'it'])('keeps nonlocalized pages on the %s default domain', (defaultLocale) => {
+    const inputs = convertNuxtPagesToSitemapEntries([{ name: 'privacy', path: '/privacy' }], {
+      normalisedLocales: autoI18n.locales,
+      multiDomainLocales: true,
+      defaultLocale: 'en',
+      strategy: 'prefix_except_default',
+      autoI18n: true,
+      autoLastmod: false,
+      isI18nMapped: true,
+      filter: {},
+    })
+    const host = autoI18n.locales.find(locale => locale.code === defaultLocale)!.defaultForDomains![0]!
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, inputs, { autoI18n: { ...autoI18n, defaultLocale }, isI18nMapped: true }, {
+      ...resolvers,
+      canonicalUrlResolver: (path: string) => new URL(path, `https://${host}`).href,
+    })
+    expect(entries.map(entry => ({ loc: entry.loc, sitemap: entry._sitemap }))).toEqual([{ loc: `https://${host}/privacy`, sitemap: defaultLocale }])
+  })
+
   it('preserves supplied remote alternatives and x-default', () => {
     const alternatives = [
       { hreflang: 'en', href: 'https://english-brand.com/about' },

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -107,6 +107,30 @@ describe('request domain sitemap entries', () => {
     }
   })
 
+  it.each([
+    { domains: undefined },
+    { domains: [] },
+  ])('excludes locales without assigned domains: $domains', ({ domains }) => {
+    const config = { ...autoI18n, locales: autoI18n.locales.map(l => l.code === 'it' ? { ...l, domains } : l) }
+    for (const inputs of [appRoutes(config), [{ loc: '/about', _i18nTransform: true }]]) {
+      const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, inputs, { autoI18n: config, isI18nMapped: true }, resolvers)
+      expect(entries.map(e => e.loc).sort()).toEqual(['https://english-brand.com/about', 'https://english-brand.com/de/about'])
+      for (const entry of entries)
+        expect(entry.alternatives?.map(a => a.hreflang).sort()).toEqual(['de', 'en', 'x-default'])
+    }
+  })
+
+  it.each(['https://ENGLISH-brand.com/', 'ENGLISH-brand.com/', 'https://english-brand.com/path?query=value'])('normalizes configured domain %s', (domain) => {
+    const config = {
+      ...autoI18n,
+      locales: autoI18n.locales.map(l => ({ ...l, domains: [l.code === 'it' ? 'italian-brand.it' : domain] })),
+    }
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, appRoutes(config), { autoI18n: config, isI18nMapped: true }, resolvers)
+    expect(entries.map(e => e.loc).sort()).toEqual(['https://english-brand.com/about', 'https://english-brand.com/de/about'])
+    for (const entry of entries)
+      expect(entry.alternatives?.map(a => a.hreflang).sort()).toEqual(['de', 'en', 'x-default'])
+  })
+
   it('does not infer unavailable alternatives from transformation seeds', () => {
     const config = { ...autoI18n, locales: autoI18n.locales.map(l => l.code === 'it' ? { ...l, domains: ['italian-brand.it'] } : l) }
     const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, ['/extra', { loc: '/it/extra', _i18nTransform: true }], { autoI18n: config, isI18nMapped: true }, resolvers)

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -62,6 +62,15 @@ describe('request domain sitemap entries', () => {
       expect(entry.alternatives).toContainEqual(expect.objectContaining({ hreflang: 'x-default', href: 'https://select-brand.com/' }))
   })
 
+  it('preserves generated alternative languages edited by a sitemap input hook', () => {
+    const inputs = appRoutes(autoI18n).map(entry => typeof entry === 'string'
+      ? entry
+      : ({ ...entry, alternatives: entry.alternatives?.filter(alternative => alternative.hreflang === 'en' && alternative.href === '/about').map(alternative => ({ ...alternative, hreflang: 'de' })) }))
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, inputs, { autoI18n, isI18nMapped: true }, resolvers)
+    for (const entry of entries)
+      expect(entry.alternatives).toContainEqual(expect.objectContaining({ hreflang: 'de', href: '/about' }))
+  })
+
   it('keeps locale-like ordinary sitemap names', () => {
     const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [{ loc: '/de/about', _sitemap: 'en-news' }], { autoI18n, isI18nMapped: false }, resolvers)
     expect(entries.map(e => ({ loc: e.loc, sitemap: e._sitemap }))).toEqual([{ loc: 'https://english-brand.com/de/about', sitemap: 'en-news' }])

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -1,0 +1,92 @@
+import type { AutoI18nConfig, NitroUrlResolvers } from '../../src/runtime/types'
+import { describe, expect, it } from 'vitest'
+import { resolveSitemapEntries } from '../../src/runtime/server/sitemap/builder/entries'
+import { convertNuxtPagesToSitemapEntries } from '../../src/utils-internal/nuxtSitemap'
+
+const domains = ['english-brand.com', 'german-brand.de', 'italian-brand.it']
+const autoI18n: AutoI18nConfig = {
+  defaultLocale: 'en',
+  strategy: 'prefix_except_default',
+  multiDomainLocales: true,
+  locales: ['en', 'de', 'it'].map((code, i) => ({ code, _hreflang: code, _sitemap: code, domains, defaultForDomains: [domains[i]!] })),
+}
+const resolvers = {
+  canonicalUrlResolver: (path: string) => new URL(path, 'https://english-brand.com').href,
+  fixSlashes: (path: string) => path,
+} as NitroUrlResolvers
+
+function appRoutes(config: AutoI18nConfig) {
+  return convertNuxtPagesToSitemapEntries([
+    { name: 'about___en___default', path: '/about' },
+    ...['en', 'de', 'it'].map(code => ({ name: `about___${code}`, path: `/${code}/about` })),
+  ], {
+    normalisedLocales: config.locales,
+    multiDomainLocales: config.multiDomainLocales,
+    defaultLocale: config.defaultLocale,
+    strategy: config.strategy,
+    autoI18n: true,
+    autoLastmod: false,
+    isI18nMapped: true,
+    filter: {},
+  })
+}
+
+describe('request domain sitemap entries', () => {
+  it('preserves supplied remote alternatives and x-default', () => {
+    const alternatives = [
+      { hreflang: 'en', href: 'https://english-brand.com/about' },
+      { hreflang: 'de', href: 'https://german-brand.de/ueber' },
+      { hreflang: 'x-default', href: 'https://select-brand.com/' },
+    ]
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [{ loc: '/about', alternatives }], { autoI18n, isI18nMapped: true }, resolvers)
+    expect(entries[0]?.alternatives).toEqual(alternatives)
+  })
+
+  it('keeps locale-like ordinary sitemap names', () => {
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [{ loc: '/de/about', _sitemap: 'en-news' }], { autoI18n, isI18nMapped: false }, resolvers)
+    expect(entries.map(e => ({ loc: e.loc, sitemap: e._sitemap }))).toEqual([{ loc: 'https://english-brand.com/de/about', sitemap: 'en-news' }])
+  })
+
+  it.each(['transformed', 'restricted source', 'app routes'])('excludes unavailable locales from %s', (source) => {
+    const config = { ...autoI18n, locales: autoI18n.locales.map(l => l.code === 'it' ? { ...l, domains: ['italian-brand.it'] } : l) }
+    const inputs = source === 'app routes' ? appRoutes(config) : [{ loc: source === 'restricted source' ? '/it/extra' : '/extra', _i18nTransform: true }]
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, inputs, { autoI18n: config, isI18nMapped: true }, resolvers)
+    expect(entries.map(e => e.loc).sort()).toEqual(source !== 'app routes'
+      ? ['https://english-brand.com/de/extra', 'https://english-brand.com/extra']
+      : ['https://english-brand.com/about', 'https://english-brand.com/de/about'])
+    for (const entry of entries) {
+      expect(entry.alternatives?.map(a => a.hreflang).sort()).toEqual(['de', 'en', 'x-default'])
+    }
+  })
+
+  it('does not infer unavailable alternatives from transformation seeds', () => {
+    const config = { ...autoI18n, locales: autoI18n.locales.map(l => l.code === 'it' ? { ...l, domains: ['italian-brand.it'] } : l) }
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, ['/extra', { loc: '/it/extra', _i18nTransform: true }], { autoI18n: config, isI18nMapped: true }, resolvers)
+    for (const entry of entries)
+      expect(entry.alternatives?.some(a => a.hreflang === 'it')).toBe(false)
+  })
+
+  it('omits transformed pages available only on another domain', () => {
+    const config: AutoI18nConfig = {
+      ...autoI18n,
+      locales: autoI18n.locales.map(l => l.code === 'it' ? { ...l, domains: ['italian-brand.it'] } : l),
+      pages: { about: { en: false, de: false, it: '/informazioni' } },
+    }
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [{ loc: '/it/informazioni', _i18nTransform: true }], { autoI18n: config, isI18nMapped: true }, resolvers)
+    expect(entries).toEqual([])
+  })
+
+  it('keeps both generated default route variants', () => {
+    const config: AutoI18nConfig = { ...autoI18n, strategy: 'prefix_and_default' }
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, appRoutes(config), { autoI18n: config, isI18nMapped: true }, resolvers)
+    expect(entries.map(e => e.loc).sort()).toEqual(['/about', '/de/about', '/en/about', '/it/about'].map(path => `https://english-brand.com${path}`))
+  })
+
+  it.each(['en', 'de'])('keeps both default custom page variants for %s', (defaultLocale) => {
+    const config: AutoI18nConfig = { ...autoI18n, defaultLocale, strategy: 'prefix_and_default', pages: { about: { en: '/about', de: '/ueber', it: '/informazioni' } } }
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [{ loc: '/en/about', _i18nTransform: true }], { autoI18n: config, isI18nMapped: true }, resolvers)
+    expect(entries.map(e => e.loc).sort()).toEqual((defaultLocale === 'en'
+      ? ['/about', '/en/about', '/de/ueber', '/it/informazioni']
+      : ['/ueber', '/en/about', '/de/ueber', '/it/informazioni']).map(path => `https://english-brand.com${path}`).sort())
+  })
+})

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -32,6 +32,23 @@ function appRoutes(config: AutoI18nConfig) {
 }
 
 describe('request domain sitemap entries', () => {
+  it.each(['prefix_except_default', 'prefix_and_default'] as const)('retains prefixes without a shared domain default for %s', (strategy) => {
+    const config: AutoI18nConfig = {
+      ...autoI18n,
+      strategy,
+      locales: autoI18n.locales.map(locale => ({ ...locale, domains: [locale.code === 'en' ? 'english-brand.com' : 'shared.example'], defaultForDomains: [] })),
+    }
+    for (const inputs of [appRoutes(config), [{ loc: '/about', _i18nTransform: true }]]) {
+      const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, inputs, { autoI18n: config, isI18nMapped: true }, {
+        ...resolvers,
+        canonicalUrlResolver: path => new URL(path, 'https://shared.example').href,
+      })
+      expect(entries.map(entry => entry.loc).sort()).toEqual(['https://shared.example/de/about', 'https://shared.example/it/about'])
+      for (const entry of entries)
+        expect(entry.alternatives?.map(alternative => alternative.href).sort()).toEqual(['/de/about', '/it/about'])
+    }
+  })
+
   it.each(['en', 'de', 'it'])('keeps nonlocalized pages on the %s default domain', (defaultLocale) => {
     const inputs = convertNuxtPagesToSitemapEntries([{ name: 'privacy', path: '/privacy' }], {
       normalisedLocales: autoI18n.locales,

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -205,9 +205,13 @@ describe('request domain sitemap entries', () => {
 
   it.each(['en', 'de'])('keeps both default custom page variants for %s', (defaultLocale) => {
     const config: AutoI18nConfig = { ...autoI18n, defaultLocale, strategy: 'prefix_and_default', pages: { about: { en: '/about', de: '/ueber', it: '/informazioni' } } }
-    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [{ loc: '/en/about', _i18nTransform: true }], { autoI18n: config, isI18nMapped: true }, resolvers)
+    const host = config.locales.find(locale => locale.code === defaultLocale)!.defaultForDomains![0]!
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [{ loc: '/en/about', _i18nTransform: true }], { autoI18n: config, isI18nMapped: true }, {
+      ...resolvers,
+      canonicalUrlResolver: (path: string) => new URL(path, `https://${host}`).href,
+    })
     expect(entries.map(e => e.loc).sort()).toEqual((defaultLocale === 'en'
       ? ['/about', '/en/about', '/de/ueber', '/it/informazioni']
-      : ['/ueber', '/en/about', '/de/ueber', '/it/informazioni']).map(path => `https://english-brand.com${path}`).sort())
+      : ['/ueber', '/en/about', '/de/ueber', '/it/informazioni']).map(path => `https://${host}${path}`).sort())
   })
 })

--- a/test/unit/i18n-multi-domain-entries.test.ts
+++ b/test/unit/i18n-multi-domain-entries.test.ts
@@ -255,6 +255,22 @@ describe('request domain sitemap entries', () => {
       expect(entry.alternatives?.map(alternative => alternative.href)).not.toContain('https://english-brand.com/en/about')
   })
 
+  it.each(['en', 'de'])('expands the absolute custom page seed on the %s domain', (requestLocale) => {
+    const host = requestLocale === 'en' ? 'english-brand.com' : 'german-brand.de'
+    const config: AutoI18nConfig = {
+      ...autoI18n,
+      pages: { about: { en: '/about', de: '/ueber', it: '/informazioni' } },
+      locales: autoI18n.locales.map((locale, i) => ({ code: locale.code, _hreflang: locale.code, _sitemap: locale.code, domain: domains[i]! })),
+    }
+    // the module emits one seed per pages entry with the source locale's domain baked in
+    const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, [{ loc: 'https://english-brand.com/en/about', _i18nTransform: true }], { autoI18n: config, isI18nMapped: true }, {
+      ...resolvers,
+      canonicalUrlResolver: path => new URL(path, `https://${host}`).href,
+    })
+    expect(entries.map(entry => entry.loc)).toEqual([requestLocale === 'en' ? 'https://english-brand.com/about' : 'https://german-brand.de/ueber'])
+    expect(entries[0]?.alternatives?.map(alternative => alternative.hreflang).sort()).toEqual([requestLocale, 'x-default'].sort())
+  })
+
   it('keeps both generated default route variants', () => {
     const config: AutoI18nConfig = { ...autoI18n, strategy: 'prefix_and_default' }
     const entries = resolveSitemapEntries({ sitemapName: 'sitemap.xml' }, appRoutes(config), { autoI18n: config, isI18nMapped: true }, resolvers)

--- a/test/unit/normalise.test.ts
+++ b/test/unit/normalise.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { normaliseEntry, preNormalizeEntry } from '../../src/runtime/server/sitemap/urlset/normalise'
 
 describe('normalise', () => {
+  it('removes generated alternative provenance from final entries', () => {
+    const source = preNormalizeEntry({ loc: '/about', alternatives: [{ hreflang: 'en', href: '/about', _i18nGenerated: '/about' }] })
+    const result = normaliseEntry(source)
+    expect(result.alternatives).toEqual([{ hreflang: 'en', href: '/about' }])
+    expect(source.alternatives?.[0]?._i18nGenerated).toBe('/about')
+  })
+
   it('normalises without defaults without mutating the source entry', () => {
     const source = preNormalizeEntry({
       loc: '/page',

--- a/test/unit/xml-stream.test.ts
+++ b/test/unit/xml-stream.test.ts
@@ -37,6 +37,14 @@ afterEach(() => {
 })
 
 describe('streaming XML serializers', () => {
+  it.each(['buffered', 'streamed'])('omits internal alternative metadata from %s XML', async (mode) => {
+    const input = [{ ...urls[0]!, alternatives: [{ hreflang: 'en', href: 'https://example.com/about', _i18nGenerated: '/about' }] }]
+    const xml = mode === 'streamed'
+      ? await new Response(urlsToXmlStream(input, resolvers, config)).text()
+      : urlsToXml(input, resolvers, config)
+    expect(xml.match(/<xhtml:link[^>]+\/>/g)).toEqual(['<xhtml:link rel="alternate" hreflang="en" href="https://example.com/about" />'])
+  })
+
   it.each([false, true])('matches buffered URL XML when minify is %s', async (minify) => {
     vi.useFakeTimers()
     vi.setSystemTime('2026-07-21T12:00:00.000Z')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Resolves #601

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

With `multiDomainLocales`, sitemaps mixed domain defaults and included invalid route variants.
Use shared request-domain rules while preserving supplied alternate links and both `prefix_and_default` variants.
Proxy caches remain separated by forwarded host.
Pages with i18n disabled keep their original paths, including paths that begin with a locale code.

Uses the domain support released in `nuxtseo-shared` 5.3.16.

![Domain-specific sitemap generation through the shared runtime](https://github.com/user-attachments/assets/fbeb7134-cd40-4451-aa0a-2a2601a82151)

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).


